### PR TITLE
QA Fail 4554/missing some USFM markers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# IntelliJ config
+.idea

--- a/__tests__/AlignmentHelpers.test.js
+++ b/__tests__/AlignmentHelpers.test.js
@@ -79,6 +79,9 @@ describe("Merge Alignment into Verse Objects", () => {
   it('handles titus 1-1', () => {
     mergeTest('tit1-1');
   });
+  it('handles 1 timothy 3-16', () => {
+    mergeTest('v_1ti3-16');
+  });
 });
 
 describe("UnMerge Alignment from Verse Objects", () => {
@@ -120,6 +123,9 @@ describe("UnMerge Alignment from Verse Objects", () => {
   });
   it('handles titus 1-1 nested milestones, merged greek', () => {
     unmergeTest('tit1-1.nested_milestones_merged_greek');
+  });
+  it('handles 1 timothy 3-16', () => {
+    unmergeTest('v_1ti3-16');
   });
 });
 

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/v_1ti3-16.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/v_1ti3-16.json
@@ -1,0 +1,1275 @@
+{
+  "alignedVerseString": "καὶ ὁμολογουμένως μέγα ἐστὶν τὸ τῆς εὐσεβείας μυστήριον: “ ὃς ἐφανερώθη ἐν σαρκί, ἐδικαιώθη ἐν Πνεύματι, ὤφθη ἀγγέλοις, ἐκηρύχθη ἐν ἔθνεσιν, ἐπιστεύθη ἐν κόσμῳ, ἀνελήμφθη ἐν δόξῃ.”",
+  "verseString": "It is undeniable that the revealed truth of godliness is great:\n\\q \"He appeared in the flesh,\n\\q was justified by the Spirit,\n\\q was seen by angels,\n\\q was proclaimed among nations,\n\\q was believed on in the world,\n\\q and was taken up in glory.\"\n\\s5\n\\p",
+  "verseObjects": [
+    {
+      "strong": "G36720",
+      "lemma": "ὁμολογουμένως",
+      "morph": "Gr,D,,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ὁμολογουμένως",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "It",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "is",
+          "occurrence": 1,
+          "occurrences": 2
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "undeniable",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G35880",
+      "lemma": "ὁ",
+      "morph": "Gr,EA,,,,NNS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "τὸ",
+      "children": [
+        {
+          "strong": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "zaln",
+          "type": "milestone",
+          "content": "τῆς",
+          "children": [
+            {
+              "tag": "w",
+              "type": "word",
+              "text": "that",
+              "occurrence": 1,
+              "occurrences": 1
+            },
+            {
+              "tag": "w",
+              "type": "word",
+              "text": "the",
+              "occurrence": 1,
+              "occurrences": 4
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "strong": "G34660",
+      "lemma": "μυστήριον",
+      "morph": "Gr,N,,,,,NNS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "μυστήριον",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "revealed",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "truth",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G21500",
+      "lemma": "εὐσέβεια",
+      "morph": "Gr,N,,,,,GFS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "εὐσεβείας",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "of",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "godliness",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G31730",
+      "lemma": "μέγας",
+      "morph": "Gr,NP,,,,NNS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "μέγα",
+      "children": [
+        {
+          "strong": "G15100",
+          "lemma": "εἰμί",
+          "morph": "Gr,V,IPA3,,S,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "zaln",
+          "type": "milestone",
+          "content": "ἐστὶν",
+          "children": [
+            {
+              "tag": "w",
+              "type": "word",
+              "text": "is",
+              "occurrence": 2,
+              "occurrences": 2
+            },
+            {
+              "tag": "w",
+              "type": "word",
+              "text": "great",
+              "occurrence": 1,
+              "occurrences": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": ":"
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "type": "text",
+      "text": "\""
+    },
+    {
+      "strong": "G37390",
+      "lemma": "ὅς",
+      "morph": "Gr,RR,,,,NMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ὃς",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "He",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G53190",
+      "lemma": "φανερόω",
+      "morph": "Gr,V,IAP3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἐφανερώθη",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "appeared",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G17220",
+      "lemma": "ἐν",
+      "morph": "Gr,P,,,,,D,,,",
+      "occurrence": 1,
+      "occurrences": 5,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἐν",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "in",
+          "occurrence": 1,
+          "occurrences": 3
+        }
+      ]
+    },
+    {
+      "strong": "G45610",
+      "lemma": "σάρξ",
+      "morph": "Gr,N,,,,,DFS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "σαρκί",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "the",
+          "occurrence": 2,
+          "occurrences": 4
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "flesh",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "strong": "G13440",
+      "lemma": "δικαιόω",
+      "morph": "Gr,V,IAP3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἐδικαιώθη",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "was",
+          "occurrence": 1,
+          "occurrences": 5
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "justified",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G17220",
+      "lemma": "ἐν",
+      "morph": "Gr,P,,,,,D,,,",
+      "occurrence": 2,
+      "occurrences": 5,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἐν",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "by",
+          "occurrence": 1,
+          "occurrences": 2
+        }
+      ]
+    },
+    {
+      "strong": "G41510",
+      "lemma": "πνεῦμα",
+      "morph": "Gr,N,,,,,DNS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "Πνεύματι",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "the",
+          "occurrence": 3,
+          "occurrences": 4
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "Spirit",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "strong": "G37080",
+      "lemma": "ὁράω",
+      "morph": "Gr,V,IAP3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ὤφθη",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "was",
+          "occurrence": 2,
+          "occurrences": 5
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "seen",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G00320",
+      "lemma": "ἄγγελος",
+      "morph": "Gr,N,,,,,DMP,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἀγγέλοις",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "by",
+          "occurrence": 2,
+          "occurrences": 2
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "angels",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "strong": "G27840",
+      "lemma": "κηρύσσω",
+      "morph": "Gr,V,IAP3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἐκηρύχθη",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "was",
+          "occurrence": 3,
+          "occurrences": 5
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "proclaimed",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G17220",
+      "lemma": "ἐν",
+      "morph": "Gr,P,,,,,D,,,",
+      "occurrence": 3,
+      "occurrences": 5,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἐν",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "among",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G14840",
+      "lemma": "ἔθνος",
+      "morph": "Gr,N,,,,,DNP,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἔθνεσιν",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "nations",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "strong": "G41000",
+      "lemma": "πιστεύω",
+      "morph": "Gr,V,IAP3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἐπιστεύθη",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "was",
+          "occurrence": 4,
+          "occurrences": 5
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "believed",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "on",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G17220",
+      "lemma": "ἐν",
+      "morph": "Gr,P,,,,,D,,,",
+      "occurrence": 4,
+      "occurrences": 5,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἐν",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "in",
+          "occurrence": 2,
+          "occurrences": 3
+        }
+      ]
+    },
+    {
+      "strong": "G28890",
+      "lemma": "κόσμος",
+      "morph": "Gr,N,,,,,DMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "κόσμῳ",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "the",
+          "occurrence": 4,
+          "occurrences": 4
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "world",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "strong": "G25320",
+      "lemma": "καί",
+      "morph": "Gr,CC,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "καὶ",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "and",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G03530",
+      "lemma": "ἀναλαμβάνω",
+      "morph": "Gr,V,IAP3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἀνελήμφθη",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "was",
+          "occurrence": 5,
+          "occurrences": 5
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "taken",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "up",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "strong": "G17220",
+      "lemma": "ἐν",
+      "morph": "Gr,P,,,,,D,,,",
+      "occurrence": 5,
+      "occurrences": 5,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "ἐν",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "in",
+          "occurrence": 3,
+          "occurrences": 3
+        }
+      ]
+    },
+    {
+      "strong": "G13910",
+      "lemma": "δόξα",
+      "morph": "Gr,N,,,,,DFS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "δόξῃ",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "glory",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": "."
+    },
+    {
+      "type": "text",
+      "text": "\""
+    },
+    {
+      "tag": "s5",
+      "type": "section",
+      "text": "\n"
+    },
+    {
+      "tag": "p",
+      "type": "paragraph"
+    }
+  ],
+  "alignment": [
+    {
+      "topWords": [
+        {
+          "word": "καὶ",
+          "strong": "G25320",
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "and",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ὁμολογουμένως",
+          "strong": "G36720",
+          "lemma": "ὁμολογουμένως",
+          "morph": "Gr,D,,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "It",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        },
+        {
+          "word": "is",
+          "occurrence": 1,
+          "occurrences": 2
+          
+        },
+        {
+          "word": "undeniable",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "μέγα",
+          "strong": "G31730",
+          "lemma": "μέγας",
+          "morph": "Gr,NP,,,,NNS,",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "ἐστὶν",
+          "strong": "G15100",
+          "lemma": "εἰμί",
+          "morph": "Gr,V,IPA3,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "is",
+          "occurrence": 2,
+          "occurrences": 2
+          
+        },
+        {
+          "word": "great",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "τὸ",
+          "strong": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,NNS,",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "τῆς",
+          "strong": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "that",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        },
+        {
+          "word": "the",
+          "occurrence": 1,
+          "occurrences": 4
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "εὐσεβείας",
+          "strong": "G21500",
+          "lemma": "εὐσέβεια",
+          "morph": "Gr,N,,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "of",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        },
+        {
+          "word": "godliness",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "μυστήριον",
+          "strong": "G34660",
+          "lemma": "μυστήριον",
+          "morph": "Gr,N,,,,,NNS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "revealed",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        },
+        {
+          "word": "truth",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ὃς",
+          "strong": "G37390",
+          "lemma": "ὅς",
+          "morph": "Gr,RR,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "He",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐφανερώθη",
+          "strong": "G53190",
+          "lemma": "φανερόω",
+          "morph": "Gr,V,IAP3,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "appeared",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐν",
+          "strong": "G17220",
+          "lemma": "ἐν",
+          "morph": "Gr,P,,,,,D,,,",
+          "occurrence": 1,
+          "occurrences": 5
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "in",
+          "occurrence": 1,
+          "occurrences": 3
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "σαρκί",
+          "strong": "G45610",
+          "lemma": "σάρξ",
+          "morph": "Gr,N,,,,,DFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "the",
+          "occurrence": 2,
+          "occurrences": 4
+          
+        },
+        {
+          "word": "flesh",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐδικαιώθη",
+          "strong": "G13440",
+          "lemma": "δικαιόω",
+          "morph": "Gr,V,IAP3,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "was",
+          "occurrence": 1,
+          "occurrences": 5
+          
+        },
+        {
+          "word": "justified",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐν",
+          "strong": "G17220",
+          "lemma": "ἐν",
+          "morph": "Gr,P,,,,,D,,,",
+          "occurrence": 2,
+          "occurrences": 5
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "by",
+          "occurrence": 1,
+          "occurrences": 2
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Πνεύματι",
+          "strong": "G41510",
+          "lemma": "πνεῦμα",
+          "morph": "Gr,N,,,,,DNS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "the",
+          "occurrence": 3,
+          "occurrences": 4
+          
+        },
+        {
+          "word": "Spirit",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ὤφθη",
+          "strong": "G37080",
+          "lemma": "ὁράω",
+          "morph": "Gr,V,IAP3,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "was",
+          "occurrence": 2,
+          "occurrences": 5
+          
+        },
+        {
+          "word": "seen",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀγγέλοις",
+          "strong": "G00320",
+          "lemma": "ἄγγελος",
+          "morph": "Gr,N,,,,,DMP,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "by",
+          "occurrence": 2,
+          "occurrences": 2
+          
+        },
+        {
+          "word": "angels",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐκηρύχθη",
+          "strong": "G27840",
+          "lemma": "κηρύσσω",
+          "morph": "Gr,V,IAP3,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "was",
+          "occurrence": 3,
+          "occurrences": 5
+          
+        },
+        {
+          "word": "proclaimed",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐν",
+          "strong": "G17220",
+          "lemma": "ἐν",
+          "morph": "Gr,P,,,,,D,,,",
+          "occurrence": 3,
+          "occurrences": 5
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "among",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἔθνεσιν",
+          "strong": "G14840",
+          "lemma": "ἔθνος",
+          "morph": "Gr,N,,,,,DNP,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "nations",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐπιστεύθη",
+          "strong": "G41000",
+          "lemma": "πιστεύω",
+          "morph": "Gr,V,IAP3,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "was",
+          "occurrence": 4,
+          "occurrences": 5
+          
+        },
+        {
+          "word": "believed",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        },
+        {
+          "word": "on",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐν",
+          "strong": "G17220",
+          "lemma": "ἐν",
+          "morph": "Gr,P,,,,,D,,,",
+          "occurrence": 4,
+          "occurrences": 5
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "in",
+          "occurrence": 2,
+          "occurrences": 3
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κόσμῳ",
+          "strong": "G28890",
+          "lemma": "κόσμος",
+          "morph": "Gr,N,,,,,DMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "the",
+          "occurrence": 4,
+          "occurrences": 4
+          
+        },
+        {
+          "word": "world",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀνελήμφθη",
+          "strong": "G03530",
+          "lemma": "ἀναλαμβάνω",
+          "morph": "Gr,V,IAP3,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "was",
+          "occurrence": 5,
+          "occurrences": 5
+          
+        },
+        {
+          "word": "taken",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        },
+        {
+          "word": "up",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐν",
+          "strong": "G17220",
+          "lemma": "ἐν",
+          "morph": "Gr,P,,,,,D,,,",
+          "occurrence": 5,
+          "occurrences": 5
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "in",
+          "occurrence": 3,
+          "occurrences": 3
+          
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "δόξῃ",
+          "strong": "G13910",
+          "lemma": "δόξα",
+          "morph": "Gr,N,,,,,DFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "glory",
+          "occurrence": 1,
+          "occurrences": 1
+          
+        }
+      ]
+    }
+  ],
+  "wordBank": []
+}

--- a/lib/js/aligner.js
+++ b/lib/js/aligner.js
@@ -178,8 +178,8 @@ var merge = exports.merge = function merge(alignments, wordBank, verseString) {
  * @param {Array} alignments - array of aligned word objects {bottomWords, topWords}
  * @param {Array} wordBank - array of unused topWords for aligning
  * @param {Object} verseObjects - verse objects from verse string to be checked
- * @return {boolean} - returns if the given verse objects from a string are contained in
- * the given alignments
+ * @return {Array} - returns array of word verse objects from a string that are not contained in
+ *                      the given alignments
  */
 function verseStringWordsContainedInAlignments(alignments, wordBank, verseObjects) {
   return verseObjects.filter(function (verseObject) {

--- a/lib/js/utils/verseObjects.js
+++ b/lib/js/utils/verseObjects.js
@@ -165,8 +165,16 @@ var getOrderedVerseObjectsFromString = exports.getOrderedVerseObjectsFromString 
   }).join(' ');
   var nonWordVerseObjectCount = 0;
   _verseObjects.forEach(function (_verseObject) {
-    if (_verseObject.text) {
-      _stringPunctuationTokenizer2.default.tokenizeWithPunctuation(_verseObject.text).forEach(function (text) {
+    var vsObjText = _verseObject.text;
+    if (vsObjText && vsObjText.trim()) {
+      // only if non-whitespace characters in text
+      if (_verseObject.type !== 'text') {
+        // preseserve non-text verseObject except for text part which will be split into words
+        delete _verseObject.text;
+        verseObjects.push(_verseObject);
+        nonWordVerseObjectCount++;
+      }
+      _stringPunctuationTokenizer2.default.tokenizeWithPunctuation(vsObjText).forEach(function (text) {
         var verseObject = void 0;
         if (_stringPunctuationTokenizer2.default.word.test(text)) {
           // if the text has word characters, its a word object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.0.1",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A library for handling word alignment",
   "main": "lib/index.js",
   "scripts": {

--- a/src/js/aligner.js
+++ b/src/js/aligner.js
@@ -119,8 +119,8 @@ export const merge = (alignments, wordBank, verseString,
  * @param {Array} alignments - array of aligned word objects {bottomWords, topWords}
  * @param {Array} wordBank - array of unused topWords for aligning
  * @param {Object} verseObjects - verse objects from verse string to be checked
- * @return {boolean} - returns if the given verse objects from a string are contained in
- * the given alignments
+ * @return {Array} - returns array of word verse objects from a string that are not contained in
+ *                      the given alignments
  */
 export function verseStringWordsContainedInAlignments(
   alignments, wordBank, verseObjects) {

--- a/src/js/utils/verseObjects.js
+++ b/src/js/utils/verseObjects.js
@@ -115,8 +115,15 @@ export const getOrderedVerseObjectsFromString = string => {
     .join(' ');
   let nonWordVerseObjectCount = 0;
   _verseObjects.forEach(_verseObject => {
-    if (_verseObject.text) {
-      tokenizer.tokenizeWithPunctuation(_verseObject.text).forEach(text => {
+    let vsObjText = _verseObject.text;
+    if (vsObjText && vsObjText.trim()) { // only if non-whitespace characters in text
+      if ((_verseObject.type !== 'text')) {
+        // preseserve non-text verseObject except for text part which will be split into words
+        delete _verseObject.text;
+        verseObjects.push(_verseObject);
+        nonWordVerseObjectCount++;
+      }
+      tokenizer.tokenizeWithPunctuation(vsObjText).forEach(text => {
         let verseObject;
         if (tokenizer.word.test(text)) { // if the text has word characters, its a word object
           const wordIndex = verseObjects.length - nonWordVerseObjectCount;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fix problem that usfm objects were being stripped out if followed by text.

#### Please include detailed Test instructions for your pull request:
- test setup:
  - test with latest tCore develop branch
  - npm i
  - npm run update-apps
  -  npm i translationCoreApps/word-aligner#bugfix-mcleanb-4554/someUsfmMarkersMissingOnExport
  - npm start

- Testing:
  - import [55-1TI.usfm.zip](https://github.com/unfoldingWord-dev/translationCore/files/2172354/55-1TI.usfm.zip) and align a few words.
  - export project as USFM3.
  - verify the exported file has 17 \p markers, 6 \q markers, and 45 \s5 markers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/word-aligner/1)
<!-- Reviewable:end -->
