### PR TITLE
Bugfix 5063/Fixes for white space on USFM export

### DIFF
--- a/__tests__/AlignmentHelpers.test.js
+++ b/__tests__/AlignmentHelpers.test.js
@@ -35,6 +35,12 @@ describe("Merge Alignment into Verse Objects", () => {
   it('handles matt 1-1', () => {
     mergeTest('matt1-1');
   });
+  it('handles mat-4-6', () => {
+    mergeTest('mat-4-6');
+  });
+  it('handles mat-4-6.whitespace', () => {
+    mergeTest('mat-4-6.whitespace');
+  });
   it('handles noncontiguous', () => {
     mergeTest('noncontiguous');
   });
@@ -97,6 +103,12 @@ describe("UnMerge Alignment from Verse Objects", () => {
   it('handles matt 1-1', () => {
     unmergeTest('matt1-1');
   });
+  it('handles mat-4-6', () => {
+    unmergeTest('mat-4-6');
+  });
+  it('handles mat-4-6.whitespace', () => {
+    unmergeTest('mat-4-6.whitespace');
+  });
   it('handles noncontiguous', () => {
     unmergeTest('noncontiguous');
   });
@@ -132,6 +144,9 @@ describe("export USFM3 from Verse Objects", () => {
   });
   it('handles acts 1-4', () => {
     exportTest('acts-1-4');
+  });
+  it('handles mat-4-6.whitespace', () => {
+    exportTest('mat-4-6.whitespace');
   });
 });
 
@@ -282,6 +297,21 @@ const unmergeTest = (name = {}) => {
   expect(output).toEqual({alignment, wordBank});
 };
 
+function normalizeAtributes(tag, source) {
+  let parts = source.split(tag);
+  const length = parts.length;
+  for (let i = 1; i < length; i++) {
+    const part = parts[i];
+    let lines = part.split('\n');
+    let attributes = lines[0].split(' ');
+    attributes = attributes.sort();
+    lines[0] = attributes.join(' ');
+    parts[i] = lines.join('\n');
+  }
+  const normalized = parts.join(tag);
+  return normalized;
+}
+
 /**
  * Generator for testing merging of alignment into verseObjects
  * @param {string} name - the name of the test files to use. e.g. `valid` will test `valid.usfm` to `valid.json`
@@ -306,6 +336,9 @@ const exportTest = (name = {}) => {
   if (usfm.substr(0, 1) === ' ') {
     usfm = usfm.substr(1);
   }
-  expect(usfm).toEqual(expectedUsfm);
+  const tag = "\\zaln-s | ";
+  const outputNormal = normalizeAtributes(tag, usfm);
+  const expectedNormal = normalizeAtributes(tag, expectedUsfm);
+  expect(outputNormal).toEqual(expectedNormal);
 };
 

--- a/__tests__/VerseObjectUtils.test.js
+++ b/__tests__/VerseObjectUtils.test.js
@@ -308,6 +308,20 @@ describe("getWordListFromVerseObjectArray", () => {
     const verseWords = VerseObjectUtils.mergeVerseData(results);
     expect(verseWords).toEqual(expected);
   });
+
+  it('handles en ULT', () => {
+    // given
+    const testFile = path.join('__tests__', 'fixtures', 'verseObjects', 'mat-4-6.json');
+    const testData = fs.readJSONSync(testFile);
+    const expected = "and said to him If you are the Son of God throw yourself down for it is written He will command his angels to take care of you and They will lift you up in their hands so that you will not hit your foot against a stone";
+
+    // when
+    const results = VerseObjectUtils.getWordListFromVerseObjectArray(testData);
+
+    // then
+    const verseWords = VerseObjectUtils.mergeVerseData(results);
+    expect(verseWords).toEqual(expected);
+  });
 });
 
 describe("getWordListForVerse", () => {

--- a/__tests__/VerseObjectUtils.test.js
+++ b/__tests__/VerseObjectUtils.test.js
@@ -309,3 +309,17 @@ describe("getWordListFromVerseObjectArray", () => {
     expect(verseWords).toEqual(expected);
   });
 });
+
+describe("getWordListForVerse", () => {
+  it('handles arrays with punctuation', () => {
+    // given
+    const testFile = path.join('__tests__', 'fixtures', 'verseObjects', 'heb-12-27.grc.json');
+    const testData = fs.readJSONSync(testFile);
+
+    // when
+    const results = VerseObjectUtils.getWordListForVerse(testData.verseObjects);
+
+    // then
+    expect(results).toEqual(testData.wordList);
+  });
+});

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.json
@@ -306,7 +306,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "text": "'",
@@ -476,7 +477,8 @@
     },
     {
       "tag": "m",
-      "type": "paragraph"
+      "type": "paragraph",
+      "nextChar": " "
     },
     {
       "children": [
@@ -503,7 +505,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "text": "'",
@@ -631,7 +634,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "children": [

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.json
@@ -1,0 +1,1658 @@
+{
+  "alignedVerseString": "καὶ λέγει αὐτῷ, “εἰ Υἱὸς εἶ τοῦ Θεοῦ, βάλε σεαυτὸν κάτω; γέγραπται γὰρ, ὅτι τοῖς‘ ἀγγέλοις αὐτοῦ ἐντελεῖται περὶ σοῦ’, καὶ, ἐπὶ‘ χειρῶν ἀροῦσίν σε, μήποτε προσκόψῃς πρὸς λίθον τὸν πόδα σου.’”",
+  "verseString": "and said to him, \"If you are the Son of God, throw yourself down, for it is written,\n\\q 'He will command his angels to take care of you,'\n\\m  and,\n\\q 'They will lift you up in their hands,\n\\q so that you will not hit your foot against a stone.'\"\n\\m\n\n\\s5",
+  "verseObjects": [
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 2,
+          "tag": "w",
+          "text": "and",
+          "type": "word"
+        }
+      ],
+      "content": "καὶ",
+      "lemma": "καί",
+      "morph": "Gr,CC,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 2,
+      "strong": "G25320",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "said",
+          "type": "word"
+        }
+      ],
+      "content": "λέγει",
+      "lemma": "λέγω",
+      "morph": "Gr,V,IPA3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G30040",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 2,
+          "tag": "w",
+          "text": "to",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "him",
+          "type": "word"
+        }
+      ],
+      "content": "αὐτῷ",
+      "lemma": "αὐτός",
+      "morph": "Gr,RP,,,3DMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G08460",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ", ",
+      "type": "text"
+    },
+    {
+      "text": "\"",
+      "type": "text"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "If",
+          "type": "word"
+        }
+      ],
+      "content": "εἰ",
+      "lemma": "εἰ",
+      "morph": "Gr,CS,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G14870",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 4,
+          "tag": "w",
+          "text": "you",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "are",
+          "type": "word"
+        }
+      ],
+      "content": "εἶ",
+      "lemma": "εἰμί",
+      "morph": "Gr,V,IPA2,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G15100",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "the",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "Son",
+          "type": "word"
+        }
+      ],
+      "content": "Υἱὸς",
+      "lemma": "υἱός",
+      "morph": "Gr,N,,,,,NMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G52070",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "occurrence": 1,
+              "occurrences": 2,
+              "tag": "w",
+              "text": "of",
+              "type": "word"
+            },
+            {
+              "occurrence": 1,
+              "occurrences": 1,
+              "tag": "w",
+              "text": "God",
+              "type": "word"
+            }
+          ],
+          "content": "Θεοῦ",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G23160",
+          "tag": "zaln",
+          "type": "milestone"
+        }
+      ],
+      "content": "τοῦ",
+      "lemma": "ὁ",
+      "morph": "Gr,EA,,,,GMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G35880",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ", ",
+      "type": "text"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "throw",
+          "type": "word"
+        }
+      ],
+      "content": "βάλε",
+      "lemma": "βάλλω",
+      "morph": "Gr,V,MAA2,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G09060",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "yourself",
+          "type": "word"
+        }
+      ],
+      "content": "σεαυτὸν",
+      "lemma": "σεαυτοῦ",
+      "morph": "Gr,RE,,,2AMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G45720",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "down",
+          "type": "word"
+        }
+      ],
+      "content": "κάτω",
+      "lemma": "κάτω",
+      "morph": "Gr,D,,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G27360",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ", ",
+      "type": "text"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "for",
+          "type": "word"
+        }
+      ],
+      "content": "γὰρ",
+      "lemma": "γάρ",
+      "morph": "Gr,CC,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G10630",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "it",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "is",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "written",
+          "type": "word"
+        }
+      ],
+      "content": "γέγραπται",
+      "lemma": "γράφω",
+      "morph": "Gr,V,IEP3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G11250",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ",\n",
+      "type": "text"
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "text": "'",
+      "type": "text"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "He",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 3,
+          "tag": "w",
+          "text": "will",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "command",
+          "type": "word"
+        }
+      ],
+      "content": "ἐντελεῖται",
+      "lemma": "ἐντέλλω",
+      "morph": "Gr,V,IFM3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G17810",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "his",
+          "type": "word"
+        }
+      ],
+      "content": "αὐτοῦ",
+      "lemma": "αὐτός",
+      "morph": "Gr,RP,,,3GMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G08460",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "occurrence": 1,
+                  "occurrences": 1,
+                  "tag": "w",
+                  "text": "angels",
+                  "type": "word"
+                }
+              ],
+              "content": "ἀγγέλοις",
+              "lemma": "ἄγγελος",
+              "morph": "Gr,N,,,,,DMP,",
+              "occurrence": 1,
+              "occurrences": 1,
+              "strong": "G00320",
+              "tag": "zaln",
+              "type": "milestone"
+            }
+          ],
+          "content": "τοῖς",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,DMP,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G35880",
+          "tag": "zaln",
+          "type": "milestone"
+        }
+      ],
+      "content": "ὅτι",
+      "lemma": "ὅτι",
+      "morph": "Gr,CS,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G37540",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 2,
+          "occurrences": 2,
+          "tag": "w",
+          "text": "to",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "take",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "care",
+          "type": "word"
+        },
+        {
+          "occurrence": 2,
+          "occurrences": 2,
+          "tag": "w",
+          "text": "of",
+          "type": "word"
+        }
+      ],
+      "content": "περὶ",
+      "lemma": "περί",
+      "morph": "Gr,P,,,,,G,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G40120",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 2,
+          "occurrences": 4,
+          "tag": "w",
+          "text": "you",
+          "type": "word"
+        }
+      ],
+      "content": "σοῦ",
+      "lemma": "σύ",
+      "morph": "Gr,RP,,,2G,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G47710",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "text": "'\n",
+      "type": "text"
+    },
+    {
+      "tag": "m",
+      "type": "paragraph"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 2,
+          "occurrences": 2,
+          "tag": "w",
+          "text": "and",
+          "type": "word"
+        }
+      ],
+      "content": "καὶ",
+      "lemma": "καί",
+      "morph": "Gr,CC,,,,,,,,",
+      "occurrence": 2,
+      "occurrences": 2,
+      "strong": "G25320",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ",\n",
+      "type": "text"
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "text": "'",
+      "type": "text"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "They",
+          "type": "word"
+        },
+        {
+          "occurrence": 2,
+          "occurrences": 3,
+          "tag": "w",
+          "text": "will",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "lift",
+          "type": "word"
+        }
+      ],
+      "content": "ἀροῦσίν",
+      "lemma": "αἴρω",
+      "morph": "Gr,V,IFA3,,P,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G01420",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 3,
+          "occurrences": 4,
+          "tag": "w",
+          "text": "you",
+          "type": "word"
+        }
+      ],
+      "content": "σε",
+      "lemma": "σύ",
+      "morph": "Gr,RP,,,2A,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G47710",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "up",
+          "type": "word"
+        }
+      ],
+      "content": "ἀροῦσίν",
+      "lemma": "αἴρω",
+      "morph": "Gr,V,IFA3,,P,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G01420",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "in",
+          "type": "word"
+        }
+      ],
+      "content": "ἐπὶ",
+      "lemma": "ἐπί",
+      "morph": "Gr,P,,,,,G,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G19090",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "their",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "hands",
+          "type": "word"
+        }
+      ],
+      "content": "χειρῶν",
+      "lemma": "χείρ",
+      "morph": "Gr,N,,,,,GFP,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G54950",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ",\n",
+      "type": "text"
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "so",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "that",
+          "type": "word"
+        }
+      ],
+      "content": "μήποτε",
+      "lemma": "μήποτε",
+      "morph": "Gr,CS,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G33790",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 4,
+          "occurrences": 4,
+          "tag": "w",
+          "text": "you",
+          "type": "word"
+        },
+        {
+          "occurrence": 3,
+          "occurrences": 3,
+          "tag": "w",
+          "text": "will",
+          "type": "word"
+        }
+      ],
+      "content": "προσκόψῃς",
+      "lemma": "προσκόπτω",
+      "morph": "Gr,V,SAA2,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G43500",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "not",
+          "type": "word"
+        }
+      ],
+      "content": "μήποτε",
+      "lemma": "μήποτε",
+      "morph": "Gr,CS,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G33790",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "hit",
+          "type": "word"
+        }
+      ],
+      "content": "προσκόψῃς",
+      "lemma": "προσκόπτω",
+      "morph": "Gr,V,SAA2,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G43500",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "your",
+          "type": "word"
+        }
+      ],
+      "content": "σου",
+      "lemma": "σύ",
+      "morph": "Gr,RP,,,2G,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G47710",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "occurrence": 1,
+              "occurrences": 1,
+              "tag": "w",
+              "text": "foot",
+              "type": "word"
+            }
+          ],
+          "content": "πόδα",
+          "lemma": "πούς",
+          "morph": "Gr,N,,,,,AMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G42280",
+          "tag": "zaln",
+          "type": "milestone"
+        }
+      ],
+      "content": "τὸν",
+      "lemma": "ὁ",
+      "morph": "Gr,EA,,,,AMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G35880",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "against",
+          "type": "word"
+        }
+      ],
+      "content": "πρὸς",
+      "lemma": "πρός",
+      "morph": "Gr,P,,,,,A,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G43140",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "a",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "stone",
+          "type": "word"
+        }
+      ],
+      "content": "λίθον",
+      "lemma": "λίθος",
+      "morph": "Gr,N,,,,,AMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G30370",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ".",
+      "type": "text"
+    },
+    {
+      "text": "'",
+      "type": "text"
+    },
+    {
+      "text": "\"\n",
+      "type": "text"
+    },
+    {
+      "nextChar": "\n",
+      "tag": "m",
+      "type": "paragraph"
+    },
+    {
+      "text": "\n",
+      "type": "text"
+    },
+    {
+      "tag": "s5",
+      "type": "section"
+    }
+  ],
+  "wordList": [
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,NNS,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τὸ",
+      "type": "word"
+    },
+    {
+      "lemma": "δέ",
+      "morph": "Gr,CC,,,,,,,,",
+      "strong": "G11610",
+      "tag": "w",
+      "text": "δὲ",
+      "type": "word"
+    },
+    {
+      "text": ",\n“",
+      "type": "text"
+    },
+    {
+      "lemma": "ἔτι",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G20890",
+      "tag": "w",
+      "text": "ἔτι",
+      "type": "word"
+    },
+    {
+      "lemma": "ἅπαξ",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G05300",
+      "tag": "w",
+      "text": "ἅπαξ",
+      "type": "word"
+    },
+    {
+      "text": "”,",
+      "type": "text"
+    },
+    {
+      "lemma": "δηλόω",
+      "morph": "Gr,V,IPA3,,S,",
+      "strong": "G12130",
+      "tag": "w",
+      "text": "δηλοῖ",
+      "type": "word"
+    },
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,GNP,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τῶν",
+      "type": "word"
+    },
+    {
+      "lemma": "σαλεύω",
+      "morph": "Gr,V,PPP,GNP,",
+      "strong": "G45310",
+      "tag": "w",
+      "text": "σαλευομένων",
+      "type": "word"
+    },
+    {
+      "lemma": "μετάθεσις",
+      "morph": "Gr,N,,,,,AFS,",
+      "strong": "G33310",
+      "tag": "w",
+      "text": "μετάθεσιν",
+      "type": "word"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "lemma": "ὡς",
+      "morph": "Gr,CS,,,,,,,,",
+      "strong": "G56130",
+      "tag": "w",
+      "text": "ὡς",
+      "tw": "rc://*/tw/dict/bible/other/like",
+      "type": "word"
+    },
+    {
+      "lemma": "ποιέω",
+      "morph": "Gr,V,PEP,GNP,",
+      "strong": "G41600",
+      "tag": "w",
+      "text": "πεποιημένων",
+      "type": "word"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "lemma": "ἵνα",
+      "morph": "Gr,CS,,,,,,,,",
+      "strong": "G24430",
+      "tag": "w",
+      "text": "ἵνα",
+      "type": "word"
+    },
+    {
+      "lemma": "μένω",
+      "morph": "Gr,V,SAA3,,S,",
+      "strong": "G33060",
+      "tag": "w",
+      "text": "μείνῃ",
+      "type": "word"
+    },
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,NNP,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τὰ",
+      "type": "word"
+    },
+    {
+      "lemma": "μή",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G33610",
+      "tag": "w",
+      "text": "μὴ",
+      "type": "word"
+    },
+    {
+      "lemma": "σαλεύω",
+      "morph": "Gr,V,PPP,NNP,",
+      "strong": "G45310",
+      "tag": "w",
+      "text": "σαλευόμενα",
+      "type": "word"
+    },
+    {
+      "text": ".\n",
+      "type": "text"
+    }
+  ],
+  "alignment": [
+    {
+      "topWords": [
+        {
+          "word": "καὶ",
+          "strong": "G25320",
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "and",
+          "occurrence": 1,
+          "occurrences": 2
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "λέγει",
+          "strong": "G30040",
+          "lemma": "λέγω",
+          "morph": "Gr,V,IPA3,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "said",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "αὐτῷ",
+          "strong": "G08460",
+          "lemma": "αὐτός",
+          "morph": "Gr,RP,,,3DMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "to",
+          "occurrence": 1,
+          "occurrences": 2
+        },
+        {
+          "word": "him",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "εἰ",
+          "strong": "G14870",
+          "lemma": "εἰ",
+          "morph": "Gr,CS,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "If",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Υἱὸς",
+          "strong": "G52070",
+          "lemma": "υἱός",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "the",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "Son",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "εἶ",
+          "strong": "G15100",
+          "lemma": "εἰμί",
+          "morph": "Gr,V,IPA2,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "you",
+          "occurrence": 1,
+          "occurrences": 4
+        },
+        {
+          "word": "are",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "τοῦ",
+          "strong": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "Θεοῦ",
+          "strong": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "of",
+          "occurrence": 1,
+          "occurrences": 2
+        },
+        {
+          "word": "God",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "βάλε",
+          "strong": "G09060",
+          "lemma": "βάλλω",
+          "morph": "Gr,V,MAA2,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "throw",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "σεαυτὸν",
+          "strong": "G45720",
+          "lemma": "σεαυτοῦ",
+          "morph": "Gr,RE,,,2AMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "yourself",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κάτω",
+          "strong": "G27360",
+          "lemma": "κάτω",
+          "morph": "Gr,D,,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "down",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "γέγραπται",
+          "strong": "G11250",
+          "lemma": "γράφω",
+          "morph": "Gr,V,IEP3,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "it",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "is",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "written",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "γὰρ",
+          "strong": "G10630",
+          "lemma": "γάρ",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "for",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ὅτι",
+          "strong": "G37540",
+          "lemma": "ὅτι",
+          "morph": "Gr,CS,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "τοῖς",
+          "strong": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,DMP,",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "ἀγγέλοις",
+          "strong": "G00320",
+          "lemma": "ἄγγελος",
+          "morph": "Gr,N,,,,,DMP,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "angels",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "αὐτοῦ",
+          "strong": "G08460",
+          "lemma": "αὐτός",
+          "morph": "Gr,RP,,,3GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "his",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐντελεῖται",
+          "strong": "G17810",
+          "lemma": "ἐντέλλω",
+          "morph": "Gr,V,IFM3,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "He",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "will",
+          "occurrence": 1,
+          "occurrences": 3
+        },
+        {
+          "word": "command",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "περὶ",
+          "strong": "G40120",
+          "lemma": "περί",
+          "morph": "Gr,P,,,,,G,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "to",
+          "occurrence": 2,
+          "occurrences": 2
+        },
+        {
+          "word": "take",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "care",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "of",
+          "occurrence": 2,
+          "occurrences": 2
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "σοῦ",
+          "strong": "G47710",
+          "lemma": "σύ",
+          "morph": "Gr,RP,,,2G,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "you",
+          "occurrence": 2,
+          "occurrences": 4
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "καὶ",
+          "strong": "G25320",
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 2,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "and",
+          "occurrence": 2,
+          "occurrences": 2
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐπὶ",
+          "strong": "G19090",
+          "lemma": "ἐπί",
+          "morph": "Gr,P,,,,,G,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "in",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "χειρῶν",
+          "strong": "G54950",
+          "lemma": "χείρ",
+          "morph": "Gr,N,,,,,GFP,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "their",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "hands",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀροῦσίν",
+          "strong": "G01420",
+          "lemma": "αἴρω",
+          "morph": "Gr,V,IFA3,,P,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "They",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "will",
+          "occurrence": 2,
+          "occurrences": 3
+        },
+        {
+          "word": "lift",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "up",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "σε",
+          "strong": "G47710",
+          "lemma": "σύ",
+          "morph": "Gr,RP,,,2A,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "you",
+          "occurrence": 3,
+          "occurrences": 4
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "μήποτε",
+          "strong": "G33790",
+          "lemma": "μήποτε",
+          "morph": "Gr,CS,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "so",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "that",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "not",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "προσκόψῃς",
+          "strong": "G43500",
+          "lemma": "προσκόπτω",
+          "morph": "Gr,V,SAA2,,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "you",
+          "occurrence": 4,
+          "occurrences": 4
+        },
+        {
+          "word": "will",
+          "occurrence": 3,
+          "occurrences": 3
+        },
+        {
+          "word": "hit",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "πρὸς",
+          "strong": "G43140",
+          "lemma": "πρός",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "against",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "λίθον",
+          "strong": "G30370",
+          "lemma": "λίθος",
+          "morph": "Gr,N,,,,,AMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "a",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "stone",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "τὸν",
+          "strong": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,AMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "πόδα",
+          "strong": "G42280",
+          "lemma": "πούς",
+          "morph": "Gr,N,,,,,AMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "foot",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "σου",
+          "strong": "G47710",
+          "lemma": "σύ",
+          "morph": "Gr,RP,,,2G,S,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "your",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    }
+  ],
+  "wordBank": []
+}
+

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.usfm
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.usfm
@@ -1,0 +1,126 @@
+
+\zaln-s | x-strong="G25320" x-lemma="καί" x-morph="Gr,CC,,,,,,,," x-occurrence="1" x-occurrences="2" x-content="καὶ"
+\w and|x-occurrence="1" x-occurrences="2"\w*
+\zaln-e\*
+\zaln-s | x-strong="G30040" x-lemma="λέγω" x-morph="Gr,V,IPA3,,S," x-occurrence="1" x-occurrences="1" x-content="λέγει"
+\w said|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G08460" x-lemma="αὐτός" x-morph="Gr,RP,,,3DMS," x-occurrence="1" x-occurrences="1" x-content="αὐτῷ"
+\w to|x-occurrence="1" x-occurrences="2"\w*
+\w him|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*, "
+\zaln-s | x-strong="G14870" x-lemma="εἰ" x-morph="Gr,CS,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="εἰ"
+\w If|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G15100" x-lemma="εἰμί" x-morph="Gr,V,IPA2,,S," x-occurrence="1" x-occurrences="1" x-content="εἶ"
+\w you|x-occurrence="1" x-occurrences="4"\w*
+\w are|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G52070" x-lemma="υἱός" x-morph="Gr,N,,,,,NMS," x-occurrence="1" x-occurrences="1" x-content="Υἱὸς"
+\w the|x-occurrence="1" x-occurrences="1"\w*
+\w Son|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G35880" x-lemma="ὁ" x-morph="Gr,EA,,,,GMS," x-occurrence="1" x-occurrences="1" x-content="τοῦ"
+\zaln-s | x-strong="G23160" x-lemma="θεός" x-morph="Gr,N,,,,,GMS," x-occurrence="1" x-occurrences="1" x-content="Θεοῦ"
+\w of|x-occurrence="1" x-occurrences="2"\w*
+\w God|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-e\*, 
+\zaln-s | x-strong="G09060" x-lemma="βάλλω" x-morph="Gr,V,MAA2,,S," x-occurrence="1" x-occurrences="1" x-content="βάλε"
+\w throw|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G45720" x-lemma="σεαυτοῦ" x-morph="Gr,RE,,,2AMS," x-occurrence="1" x-occurrences="1" x-content="σεαυτὸν"
+\w yourself|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G27360" x-lemma="κάτω" x-morph="Gr,D,,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="κάτω"
+\w down|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*, 
+\zaln-s | x-strong="G10630" x-lemma="γάρ" x-morph="Gr,CC,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="γὰρ"
+\w for|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G11250" x-lemma="γράφω" x-morph="Gr,V,IEP3,,S," x-occurrence="1" x-occurrences="1" x-content="γέγραπται"
+\w it|x-occurrence="1" x-occurrences="1"\w*
+\w is|x-occurrence="1" x-occurrences="1"\w*
+\w written|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*,
+\q '
+\zaln-s | x-strong="G17810" x-lemma="ἐντέλλω" x-morph="Gr,V,IFM3,,S," x-occurrence="1" x-occurrences="1" x-content="ἐντελεῖται"
+\w He|x-occurrence="1" x-occurrences="1"\w*
+\w will|x-occurrence="1" x-occurrences="3"\w*
+\w command|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G08460" x-lemma="αὐτός" x-morph="Gr,RP,,,3GMS," x-occurrence="1" x-occurrences="1" x-content="αὐτοῦ"
+\w his|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G37540" x-lemma="ὅτι" x-morph="Gr,CS,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="ὅτι"
+\zaln-s | x-strong="G35880" x-lemma="ὁ" x-morph="Gr,EA,,,,DMP," x-occurrence="1" x-occurrences="1" x-content="τοῖς"
+\zaln-s | x-strong="G00320" x-lemma="ἄγγελος" x-morph="Gr,N,,,,,DMP," x-occurrence="1" x-occurrences="1" x-content="ἀγγέλοις"
+\w angels|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-e\*
+\zaln-e\*
+\zaln-s | x-strong="G40120" x-lemma="περί" x-morph="Gr,P,,,,,G,,," x-occurrence="1" x-occurrences="1" x-content="περὶ"
+\w to|x-occurrence="2" x-occurrences="2"\w*
+\w take|x-occurrence="1" x-occurrences="1"\w*
+\w care|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="2" x-occurrences="2"\w*
+\zaln-e\*
+\zaln-s | x-strong="G47710" x-lemma="σύ" x-morph="Gr,RP,,,2G,S," x-occurrence="1" x-occurrences="1" x-content="σοῦ"
+\w you|x-occurrence="2" x-occurrences="4"\w*
+\zaln-e\*,'
+\m
+\zaln-s | x-strong="G25320" x-lemma="καί" x-morph="Gr,CC,,,,,,,," x-occurrence="2" x-occurrences="2" x-content="καὶ"
+\w and|x-occurrence="2" x-occurrences="2"\w*
+\zaln-e\*,
+\q '
+\zaln-s | x-strong="G01420" x-lemma="αἴρω" x-morph="Gr,V,IFA3,,P," x-occurrence="1" x-occurrences="1" x-content="ἀροῦσίν"
+\w They|x-occurrence="1" x-occurrences="1"\w*
+\w will|x-occurrence="2" x-occurrences="3"\w*
+\w lift|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G47710" x-lemma="σύ" x-morph="Gr,RP,,,2A,S," x-occurrence="1" x-occurrences="1" x-content="σε"
+\w you|x-occurrence="3" x-occurrences="4"\w*
+\zaln-e\*
+\zaln-s | x-strong="G01420" x-lemma="αἴρω" x-morph="Gr,V,IFA3,,P," x-occurrence="1" x-occurrences="1" x-content="ἀροῦσίν"
+\w up|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G19090" x-lemma="ἐπί" x-morph="Gr,P,,,,,G,,," x-occurrence="1" x-occurrences="1" x-content="ἐπὶ"
+\w in|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G54950" x-lemma="χείρ" x-morph="Gr,N,,,,,GFP," x-occurrence="1" x-occurrences="1" x-content="χειρῶν"
+\w their|x-occurrence="1" x-occurrences="1"\w*
+\w hands|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*,
+\q
+\zaln-s | x-strong="G33790" x-lemma="μήποτε" x-morph="Gr,CS,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="μήποτε"
+\w so|x-occurrence="1" x-occurrences="1"\w*
+\w that|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G43500" x-lemma="προσκόπτω" x-morph="Gr,V,SAA2,,S," x-occurrence="1" x-occurrences="1" x-content="προσκόψῃς"
+\w you|x-occurrence="4" x-occurrences="4"\w*
+\w will|x-occurrence="3" x-occurrences="3"\w*
+\zaln-e\*
+\zaln-s | x-strong="G33790" x-lemma="μήποτε" x-morph="Gr,CS,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="μήποτε"
+\w not|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G43500" x-lemma="προσκόπτω" x-morph="Gr,V,SAA2,,S," x-occurrence="1" x-occurrences="1" x-content="προσκόψῃς"
+\w hit|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G47710" x-lemma="σύ" x-morph="Gr,RP,,,2G,S," x-occurrence="1" x-occurrences="1" x-content="σου"
+\w your|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G35880" x-lemma="ὁ" x-morph="Gr,EA,,,,AMS," x-occurrence="1" x-occurrences="1" x-content="τὸν"
+\zaln-s | x-strong="G42280" x-lemma="πούς" x-morph="Gr,N,,,,,AMS," x-occurrence="1" x-occurrences="1" x-content="πόδα"
+\w foot|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-e\*
+\zaln-s | x-strong="G43140" x-lemma="πρός" x-morph="Gr,P,,,,,A,,," x-occurrence="1" x-occurrences="1" x-content="πρὸς"
+\w against|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G30370" x-lemma="λίθος" x-morph="Gr,N,,,,,AMS," x-occurrence="1" x-occurrences="1" x-content="λίθον"
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w stone|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*.'"
+\m
+
+\s5

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.whitespace.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.whitespace.json
@@ -1,0 +1,1661 @@
+{
+  "alignedVerseString": "καὶ λέγει αὐτῷ, “εἰ Υἱὸς εἶ τοῦ Θεοῦ, βάλε σεαυτὸν κάτω; γέγραπται γὰρ, ὅτι τοῖς‘ ἀγγέλοις αὐτοῦ ἐντελεῖται περὶ σοῦ’, καὶ, ἐπὶ‘ χειρῶν ἀροῦσίν σε, μήποτε προσκόψῃς πρὸς λίθον τὸν πόδα σου.’”",
+  "verseString": "and said to him, \"If you are the Son of God, throw yourself down, for it is written,\n\\q 'He will command his angels to take care of you,'\n\\m  and,\n\\q 'They will lift you up in their hands,\n\\q so that you will not hit your foot against a stone.'\"\n\\m\n\n\\s5",
+  "verseObjects": [
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 2,
+          "tag": "w",
+          "text": "and",
+          "type": "word"
+        }
+      ],
+      "content": "καὶ",
+      "lemma": "καί",
+      "morph": "Gr,CC,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 2,
+      "strong": "G25320",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "said",
+          "type": "word"
+        }
+      ],
+      "content": "λέγει",
+      "lemma": "λέγω",
+      "morph": "Gr,V,IPA3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G30040",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 2,
+          "tag": "w",
+          "text": "to",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "him",
+          "type": "word"
+        }
+      ],
+      "content": "αὐτῷ",
+      "lemma": "αὐτός",
+      "morph": "Gr,RP,,,3DMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G08460",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ", ",
+      "type": "text"
+    },
+    {
+      "text": "\"",
+      "type": "text"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "If",
+          "type": "word"
+        }
+      ],
+      "content": "εἰ",
+      "lemma": "εἰ",
+      "morph": "Gr,CS,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G14870",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 4,
+          "tag": "w",
+          "text": "you",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "are",
+          "type": "word"
+        }
+      ],
+      "content": "εἶ",
+      "lemma": "εἰμί",
+      "morph": "Gr,V,IPA2,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G15100",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "the",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "Son",
+          "type": "word"
+        }
+      ],
+      "content": "Υἱὸς",
+      "lemma": "υἱός",
+      "morph": "Gr,N,,,,,NMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G52070",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "occurrence": 1,
+              "occurrences": 2,
+              "tag": "w",
+              "text": "of",
+              "type": "word"
+            },
+            {
+              "occurrence": 1,
+              "occurrences": 1,
+              "tag": "w",
+              "text": "God",
+              "type": "word"
+            }
+          ],
+          "content": "Θεοῦ",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G23160",
+          "tag": "zaln",
+          "type": "milestone"
+        }
+      ],
+      "content": "τοῦ",
+      "lemma": "ὁ",
+      "morph": "Gr,EA,,,,GMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G35880",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ", ",
+      "type": "text"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "throw",
+          "type": "word"
+        }
+      ],
+      "content": "βάλε",
+      "lemma": "βάλλω",
+      "morph": "Gr,V,MAA2,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G09060",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "yourself",
+          "type": "word"
+        }
+      ],
+      "content": "σεαυτὸν",
+      "lemma": "σεαυτοῦ",
+      "morph": "Gr,RE,,,2AMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G45720",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "down",
+          "type": "word"
+        }
+      ],
+      "content": "κάτω",
+      "lemma": "κάτω",
+      "morph": "Gr,D,,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G27360",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ", ",
+      "type": "text"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "for",
+          "type": "word"
+        }
+      ],
+      "content": "γὰρ",
+      "lemma": "γάρ",
+      "morph": "Gr,CC,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G10630",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "it",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "is",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "written",
+          "type": "word"
+        }
+      ],
+      "content": "γέγραπται",
+      "lemma": "γράφω",
+      "morph": "Gr,V,IEP3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G11250",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ",\n",
+      "type": "text"
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "text": "'",
+      "type": "text"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "He",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 3,
+          "tag": "w",
+          "text": "will",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "command",
+          "type": "word"
+        }
+      ],
+      "content": "ἐντελεῖται",
+      "lemma": "ἐντέλλω",
+      "morph": "Gr,V,IFM3,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G17810",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "his",
+          "type": "word"
+        }
+      ],
+      "content": "αὐτοῦ",
+      "lemma": "αὐτός",
+      "morph": "Gr,RP,,,3GMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G08460",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "occurrence": 1,
+                  "occurrences": 1,
+                  "tag": "w",
+                  "text": "angels",
+                  "type": "word"
+                }
+              ],
+              "content": "ἀγγέλοις",
+              "lemma": "ἄγγελος",
+              "morph": "Gr,N,,,,,DMP,",
+              "occurrence": 1,
+              "occurrences": 1,
+              "strong": "G00320",
+              "tag": "zaln",
+              "type": "milestone"
+            }
+          ],
+          "content": "τοῖς",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,DMP,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G35880",
+          "tag": "zaln",
+          "type": "milestone"
+        }
+      ],
+      "content": "ὅτι",
+      "lemma": "ὅτι",
+      "morph": "Gr,CS,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G37540",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 2,
+          "occurrences": 2,
+          "tag": "w",
+          "text": "to",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "take",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "care",
+          "type": "word"
+        },
+        {
+          "occurrence": 2,
+          "occurrences": 2,
+          "tag": "w",
+          "text": "of",
+          "type": "word"
+        }
+      ],
+      "content": "περὶ",
+      "lemma": "περί",
+      "morph": "Gr,P,,,,,G,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G40120",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 2,
+          "occurrences": 4,
+          "tag": "w",
+          "text": "you",
+          "type": "word"
+        }
+      ],
+      "content": "σοῦ",
+      "lemma": "σύ",
+      "morph": "Gr,RP,,,2G,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G47710",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "text": "'\n",
+      "type": "text"
+    },
+    {
+      "tag": "m",
+      "type": "paragraph"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 2,
+          "occurrences": 2,
+          "tag": "w",
+          "text": "and",
+          "type": "word"
+        }
+      ],
+      "content": "καὶ",
+      "lemma": "καί",
+      "morph": "Gr,CC,,,,,,,,",
+      "occurrence": 2,
+      "occurrences": 2,
+      "strong": "G25320",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ",\n",
+      "type": "text"
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "text": "'",
+      "type": "text"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "They",
+          "type": "word"
+        },
+        {
+          "occurrence": 2,
+          "occurrences": 3,
+          "tag": "w",
+          "text": "will",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "lift",
+          "type": "word"
+        }
+      ],
+      "content": "ἀροῦσίν",
+      "lemma": "αἴρω",
+      "morph": "Gr,V,IFA3,,P,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G01420",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 3,
+          "occurrences": 4,
+          "tag": "w",
+          "text": "you",
+          "type": "word"
+        }
+      ],
+      "content": "σε",
+      "lemma": "σύ",
+      "morph": "Gr,RP,,,2A,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G47710",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "up",
+          "type": "word"
+        }
+      ],
+      "content": "ἀροῦσίν",
+      "lemma": "αἴρω",
+      "morph": "Gr,V,IFA3,,P,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G01420",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "in",
+          "type": "word"
+        }
+      ],
+      "content": "ἐπὶ",
+      "lemma": "ἐπί",
+      "morph": "Gr,P,,,,,G,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G19090",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "their",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "hands",
+          "type": "word"
+        }
+      ],
+      "content": "χειρῶν",
+      "lemma": "χείρ",
+      "morph": "Gr,N,,,,,GFP,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G54950",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ",\n",
+      "type": "text"
+    },
+    {
+      "tag": "q",
+      "type": "quote"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "so",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "that",
+          "type": "word"
+        }
+      ],
+      "content": "μήποτε",
+      "lemma": "μήποτε",
+      "morph": "Gr,CS,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G33790",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 4,
+          "occurrences": 4,
+          "tag": "w",
+          "text": "you",
+          "type": "word"
+        },
+        {
+          "occurrence": 3,
+          "occurrences": 3,
+          "tag": "w",
+          "text": "will",
+          "type": "word"
+        }
+      ],
+      "content": "προσκόψῃς",
+      "lemma": "προσκόπτω",
+      "morph": "Gr,V,SAA2,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G43500",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "not",
+          "type": "word"
+        }
+      ],
+      "content": "μήποτε",
+      "lemma": "μήποτε",
+      "morph": "Gr,CS,,,,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G33790",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "hit",
+          "type": "word"
+        }
+      ],
+      "content": "προσκόψῃς",
+      "lemma": "προσκόπτω",
+      "morph": "Gr,V,SAA2,,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G43500",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "your",
+          "type": "word"
+        }
+      ],
+      "content": "σου",
+      "lemma": "σύ",
+      "morph": "Gr,RP,,,2G,S,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G47710",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "occurrence": 1,
+              "occurrences": 1,
+              "tag": "w",
+              "text": "foot",
+              "type": "word"
+            }
+          ],
+          "content": "πόδα",
+          "lemma": "πούς",
+          "morph": "Gr,N,,,,,AMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G42280",
+          "tag": "zaln",
+          "type": "milestone"
+        }
+      ],
+      "content": "τὸν",
+      "lemma": "ὁ",
+      "morph": "Gr,EA,,,,AMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G35880",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "against",
+          "type": "word"
+        }
+      ],
+      "content": "πρὸς",
+      "lemma": "πρός",
+      "morph": "Gr,P,,,,,A,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G43140",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "a",
+          "type": "word"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "stone",
+          "type": "word"
+        }
+      ],
+      "content": "λίθον",
+      "lemma": "λίθος",
+      "morph": "Gr,N,,,,,AMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G30370",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": ".",
+      "type": "text"
+    },
+    {
+      "text": "'",
+      "type": "text"
+    },
+    {
+      "text": "\"\n",
+      "type": "text"
+    },
+    {
+      "nextChar": "\n",
+      "tag": "m",
+      "type": "paragraph"
+    },
+    {
+      "text": "\n",
+      "type": "text"
+    },
+    {
+      "tag": "s5",
+      "type": "section"
+    }
+  ],
+  "wordList": [
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,NNS,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τὸ",
+      "type": "word"
+    },
+    {
+      "lemma": "δέ",
+      "morph": "Gr,CC,,,,,,,,",
+      "strong": "G11610",
+      "tag": "w",
+      "text": "δὲ",
+      "type": "word"
+    },
+    {
+      "text": ",\n“",
+      "type": "text"
+    },
+    {
+      "lemma": "ἔτι",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G20890",
+      "tag": "w",
+      "text": "ἔτι",
+      "type": "word"
+    },
+    {
+      "lemma": "ἅπαξ",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G05300",
+      "tag": "w",
+      "text": "ἅπαξ",
+      "type": "word"
+    },
+    {
+      "text": "”,",
+      "type": "text"
+    },
+    {
+      "lemma": "δηλόω",
+      "morph": "Gr,V,IPA3,,S,",
+      "strong": "G12130",
+      "tag": "w",
+      "text": "δηλοῖ",
+      "type": "word"
+    },
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,GNP,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τῶν",
+      "type": "word"
+    },
+    {
+      "lemma": "σαλεύω",
+      "morph": "Gr,V,PPP,GNP,",
+      "strong": "G45310",
+      "tag": "w",
+      "text": "σαλευομένων",
+      "type": "word"
+    },
+    {
+      "lemma": "μετάθεσις",
+      "morph": "Gr,N,,,,,AFS,",
+      "strong": "G33310",
+      "tag": "w",
+      "text": "μετάθεσιν",
+      "type": "word"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "lemma": "ὡς",
+      "morph": "Gr,CS,,,,,,,,",
+      "strong": "G56130",
+      "tag": "w",
+      "text": "ὡς",
+      "tw": "rc://*/tw/dict/bible/other/like",
+      "type": "word"
+    },
+    {
+      "lemma": "ποιέω",
+      "morph": "Gr,V,PEP,GNP,",
+      "strong": "G41600",
+      "tag": "w",
+      "text": "πεποιημένων",
+      "type": "word"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "lemma": "ἵνα",
+      "morph": "Gr,CS,,,,,,,,",
+      "strong": "G24430",
+      "tag": "w",
+      "text": "ἵνα",
+      "type": "word"
+    },
+    {
+      "lemma": "μένω",
+      "morph": "Gr,V,SAA3,,S,",
+      "strong": "G33060",
+      "tag": "w",
+      "text": "μείνῃ",
+      "type": "word"
+    },
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,NNP,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τὰ",
+      "type": "word"
+    },
+    {
+      "lemma": "μή",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G33610",
+      "tag": "w",
+      "text": "μὴ",
+      "type": "word"
+    },
+    {
+      "lemma": "σαλεύω",
+      "morph": "Gr,V,PPP,NNP,",
+      "strong": "G45310",
+      "tag": "w",
+      "text": "σαλευόμενα",
+      "type": "word"
+    },
+    {
+      "text": ".",
+      "type": "text"
+    },
+    {
+      "text": "'",
+      "type": "text"
+    }
+  ],
+  "alignment": [
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 2,
+          "word": "and"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 2,
+          "strong": "G25320",
+          "word": "καὶ"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "said"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "λέγω",
+          "morph": "Gr,V,IPA3,,S,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G30040",
+          "word": "λέγει"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 2,
+          "word": "to"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "him"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "αὐτός",
+          "morph": "Gr,RP,,,3DMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G08460",
+          "word": "αὐτῷ"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "If"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "εἰ",
+          "morph": "Gr,CS,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G14870",
+          "word": "εἰ"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "the"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "Son"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "υἱός",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G52070",
+          "word": "Υἱὸς"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 4,
+          "word": "you"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "are"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "εἰμί",
+          "morph": "Gr,V,IPA2,,S,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G15100",
+          "word": "εἶ"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 2,
+          "word": "of"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "God"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G35880",
+          "word": "τοῦ"
+        },
+        {
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G23160",
+          "word": "Θεοῦ"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "throw"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "βάλλω",
+          "morph": "Gr,V,MAA2,,S,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G09060",
+          "word": "βάλε"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "yourself"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "σεαυτοῦ",
+          "morph": "Gr,RE,,,2AMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G45720",
+          "word": "σεαυτὸν"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "down"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "κάτω",
+          "morph": "Gr,D,,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G27360",
+          "word": "κάτω"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "it"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "is"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "written"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "γράφω",
+          "morph": "Gr,V,IEP3,,S,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G11250",
+          "word": "γέγραπται"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "for"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "γάρ",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G10630",
+          "word": "γὰρ"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "angels"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "ὅτι",
+          "morph": "Gr,CS,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G37540",
+          "word": "ὅτι"
+        },
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,DMP,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G35880",
+          "word": "τοῖς"
+        },
+        {
+          "lemma": "ἄγγελος",
+          "morph": "Gr,N,,,,,DMP,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G00320",
+          "word": "ἀγγέλοις"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "his"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "αὐτός",
+          "morph": "Gr,RP,,,3GMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G08460",
+          "word": "αὐτοῦ"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "He"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 3,
+          "word": "will"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "command"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "ἐντέλλω",
+          "morph": "Gr,V,IFM3,,S,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G17810",
+          "word": "ἐντελεῖται"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 2,
+          "occurrences": 2,
+          "word": "to"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "take"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "care"
+        },
+        {
+          "occurrence": 2,
+          "occurrences": 2,
+          "word": "of"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "περί",
+          "morph": "Gr,P,,,,,G,,,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G40120",
+          "word": "περὶ"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 2,
+          "occurrences": 4,
+          "word": "you"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "σύ",
+          "morph": "Gr,RP,,,2G,S,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G47710",
+          "word": "σοῦ"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 2,
+          "occurrences": 2,
+          "word": "and"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 2,
+          "occurrences": 2,
+          "strong": "G25320",
+          "word": "καὶ"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "in"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "ἐπί",
+          "morph": "Gr,P,,,,,G,,,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G19090",
+          "word": "ἐπὶ"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "their"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "hands"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "χείρ",
+          "morph": "Gr,N,,,,,GFP,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G54950",
+          "word": "χειρῶν"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "They"
+        },
+        {
+          "occurrence": 2,
+          "occurrences": 3,
+          "word": "will"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "lift"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "up"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "αἴρω",
+          "morph": "Gr,V,IFA3,,P,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G01420",
+          "word": "ἀροῦσίν"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 3,
+          "occurrences": 4,
+          "word": "you"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "σύ",
+          "morph": "Gr,RP,,,2A,S,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G47710",
+          "word": "σε"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "so"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "that"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "not"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "μήποτε",
+          "morph": "Gr,CS,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G33790",
+          "word": "μήποτε"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 4,
+          "occurrences": 4,
+          "word": "you"
+        },
+        {
+          "occurrence": 3,
+          "occurrences": 3,
+          "word": "will"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "hit"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "προσκόπτω",
+          "morph": "Gr,V,SAA2,,S,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G43500",
+          "word": "προσκόψῃς"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "against"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "πρός",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G43140",
+          "word": "πρὸς"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "a"
+        },
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "stone"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "λίθος",
+          "morph": "Gr,N,,,,,AMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G30370",
+          "word": "λίθον"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "foot"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,AMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G35880",
+          "word": "τὸν"
+        },
+        {
+          "lemma": "πούς",
+          "morph": "Gr,N,,,,,AMS,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G42280",
+          "word": "πόδα"
+        }
+      ]
+    },
+    {
+      "bottomWords": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "word": "your"
+        }
+      ],
+      "topWords": [
+        {
+          "lemma": "σύ",
+          "morph": "Gr,RP,,,2G,S,",
+          "occurrence": 1,
+          "occurrences": 1,
+          "strong": "G47710",
+          "word": "σου"
+        }
+      ]
+    }
+  ],
+  "wordBank": []
+}

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.whitespace.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.whitespace.json
@@ -1,6 +1,6 @@
 {
   "alignedVerseString": "καὶ λέγει αὐτῷ, “εἰ Υἱὸς εἶ τοῦ Θεοῦ, βάλε σεαυτὸν κάτω; γέγραπται γὰρ, ὅτι τοῖς‘ ἀγγέλοις αὐτοῦ ἐντελεῖται περὶ σοῦ’, καὶ, ἐπὶ‘ χειρῶν ἀροῦσίν σε, μήποτε προσκόψῃς πρὸς λίθον τὸν πόδα σου.’”",
-  "verseString": "and said to him, \"If you are the Son of God, throw yourself down, for it is written,\n\\q 'He will command his angels to take care of you,'\n\\m  and,\n\\q 'They will lift you up in their hands,\n\\q so that you will not hit your foot against a stone.'\"\n\\m\n\n\\s5",
+  "verseString": "and said to him, \"If you are the Son of God, throw yourself down, for it is written,\n\\q 'He will command his angels to take care of you,'\n\\m and,\n\\q 'They will lift you up in their hands,\n\\q so that you will not hit your foot against a stone.'\"\n\\m\n\n\\s5",
   "verseObjects": [
     {
       "children": [
@@ -306,7 +306,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "text": "'",
@@ -476,7 +477,8 @@
     },
     {
       "tag": "m",
-      "type": "paragraph"
+      "type": "paragraph",
+      "nextChar": " "
     },
     {
       "children": [
@@ -503,7 +505,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "text": "'",
@@ -631,7 +634,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "children": [

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.whitespace.usfm
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.whitespace.usfm
@@ -1,0 +1,126 @@
+
+\zaln-s | x-content="καὶ" x-lemma="καί" x-morph="Gr,CC,,,,,,,," x-occurrence="1" x-occurrences="2" x-strong="G25320"
+\w and|x-occurrence="1" x-occurrences="2"\w*
+\zaln-e\*
+\zaln-s | x-content="λέγει" x-lemma="λέγω" x-morph="Gr,V,IPA3,,S," x-occurrence="1" x-occurrences="1" x-strong="G30040"
+\w said|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="αὐτῷ" x-lemma="αὐτός" x-morph="Gr,RP,,,3DMS," x-occurrence="1" x-occurrences="1" x-strong="G08460"
+\w to|x-occurrence="1" x-occurrences="2"\w*
+\w him|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*, "
+\zaln-s | x-content="εἰ" x-lemma="εἰ" x-morph="Gr,CS,,,,,,,," x-occurrence="1" x-occurrences="1" x-strong="G14870"
+\w If|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="εἶ" x-lemma="εἰμί" x-morph="Gr,V,IPA2,,S," x-occurrence="1" x-occurrences="1" x-strong="G15100"
+\w you|x-occurrence="1" x-occurrences="4"\w*
+\w are|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="Υἱὸς" x-lemma="υἱός" x-morph="Gr,N,,,,,NMS," x-occurrence="1" x-occurrences="1" x-strong="G52070"
+\w the|x-occurrence="1" x-occurrences="1"\w*
+\w Son|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="τοῦ" x-lemma="ὁ" x-morph="Gr,EA,,,,GMS," x-occurrence="1" x-occurrences="1" x-strong="G35880"
+\zaln-s | x-content="Θεοῦ" x-lemma="θεός" x-morph="Gr,N,,,,,GMS," x-occurrence="1" x-occurrences="1" x-strong="G23160"
+\w of|x-occurrence="1" x-occurrences="2"\w*
+\w God|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-e\*, 
+\zaln-s | x-content="βάλε" x-lemma="βάλλω" x-morph="Gr,V,MAA2,,S," x-occurrence="1" x-occurrences="1" x-strong="G09060"
+\w throw|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="σεαυτὸν" x-lemma="σεαυτοῦ" x-morph="Gr,RE,,,2AMS," x-occurrence="1" x-occurrences="1" x-strong="G45720"
+\w yourself|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="κάτω" x-lemma="κάτω" x-morph="Gr,D,,,,,,,,," x-occurrence="1" x-occurrences="1" x-strong="G27360"
+\w down|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*, 
+\zaln-s | x-content="γὰρ" x-lemma="γάρ" x-morph="Gr,CC,,,,,,,," x-occurrence="1" x-occurrences="1" x-strong="G10630"
+\w for|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="γέγραπται" x-lemma="γράφω" x-morph="Gr,V,IEP3,,S," x-occurrence="1" x-occurrences="1" x-strong="G11250"
+\w it|x-occurrence="1" x-occurrences="1"\w*
+\w is|x-occurrence="1" x-occurrences="1"\w*
+\w written|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*,
+\q '
+\zaln-s | x-content="ἐντελεῖται" x-lemma="ἐντέλλω" x-morph="Gr,V,IFM3,,S," x-occurrence="1" x-occurrences="1" x-strong="G17810"
+\w He|x-occurrence="1" x-occurrences="1"\w*
+\w will|x-occurrence="1" x-occurrences="3"\w*
+\w command|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="αὐτοῦ" x-lemma="αὐτός" x-morph="Gr,RP,,,3GMS," x-occurrence="1" x-occurrences="1" x-strong="G08460"
+\w his|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="ὅτι" x-lemma="ὅτι" x-morph="Gr,CS,,,,,,,," x-occurrence="1" x-occurrences="1" x-strong="G37540"
+\zaln-s | x-content="τοῖς" x-lemma="ὁ" x-morph="Gr,EA,,,,DMP," x-occurrence="1" x-occurrences="1" x-strong="G35880"
+\zaln-s | x-content="ἀγγέλοις" x-lemma="ἄγγελος" x-morph="Gr,N,,,,,DMP," x-occurrence="1" x-occurrences="1" x-strong="G00320"
+\w angels|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-e\*
+\zaln-e\*
+\zaln-s | x-content="περὶ" x-lemma="περί" x-morph="Gr,P,,,,,G,,," x-occurrence="1" x-occurrences="1" x-strong="G40120"
+\w to|x-occurrence="2" x-occurrences="2"\w*
+\w take|x-occurrence="1" x-occurrences="1"\w*
+\w care|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="2" x-occurrences="2"\w*
+\zaln-e\*
+\zaln-s | x-content="σοῦ" x-lemma="σύ" x-morph="Gr,RP,,,2G,S," x-occurrence="1" x-occurrences="1" x-strong="G47710"
+\w you|x-occurrence="2" x-occurrences="4"\w*
+\zaln-e\*,'
+\m
+\zaln-s | x-content="καὶ" x-lemma="καί" x-morph="Gr,CC,,,,,,,," x-occurrence="2" x-occurrences="2" x-strong="G25320"
+\w and|x-occurrence="2" x-occurrences="2"\w*
+\zaln-e\*,
+\q '
+\zaln-s | x-content="ἀροῦσίν" x-lemma="αἴρω" x-morph="Gr,V,IFA3,,P," x-occurrence="1" x-occurrences="1" x-strong="G01420"
+\w They|x-occurrence="1" x-occurrences="1"\w*
+\w will|x-occurrence="2" x-occurrences="3"\w*
+\w lift|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="σε" x-lemma="σύ" x-morph="Gr,RP,,,2A,S," x-occurrence="1" x-occurrences="1" x-strong="G47710"
+\w you|x-occurrence="3" x-occurrences="4"\w*
+\zaln-e\*
+\zaln-s | x-content="ἀροῦσίν" x-lemma="αἴρω" x-morph="Gr,V,IFA3,,P," x-occurrence="1" x-occurrences="1" x-strong="G01420"
+\w up|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="ἐπὶ" x-lemma="ἐπί" x-morph="Gr,P,,,,,G,,," x-occurrence="1" x-occurrences="1" x-strong="G19090"
+\w in|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="χειρῶν" x-lemma="χείρ" x-morph="Gr,N,,,,,GFP," x-occurrence="1" x-occurrences="1" x-strong="G54950"
+\w their|x-occurrence="1" x-occurrences="1"\w*
+\w hands|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*,
+\q
+\zaln-s | x-content="μήποτε" x-lemma="μήποτε" x-morph="Gr,CS,,,,,,,," x-occurrence="1" x-occurrences="1" x-strong="G33790"
+\w so|x-occurrence="1" x-occurrences="1"\w*
+\w that|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="προσκόψῃς" x-lemma="προσκόπτω" x-morph="Gr,V,SAA2,,S," x-occurrence="1" x-occurrences="1" x-strong="G43500"
+\w you|x-occurrence="4" x-occurrences="4"\w*
+\w will|x-occurrence="3" x-occurrences="3"\w*
+\zaln-e\*
+\zaln-s | x-content="μήποτε" x-lemma="μήποτε" x-morph="Gr,CS,,,,,,,," x-occurrence="1" x-occurrences="1" x-strong="G33790"
+\w not|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="προσκόψῃς" x-lemma="προσκόπτω" x-morph="Gr,V,SAA2,,S," x-occurrence="1" x-occurrences="1" x-strong="G43500"
+\w hit|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="σου" x-lemma="σύ" x-morph="Gr,RP,,,2G,S," x-occurrence="1" x-occurrences="1" x-strong="G47710"
+\w your|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="τὸν" x-lemma="ὁ" x-morph="Gr,EA,,,,AMS," x-occurrence="1" x-occurrences="1" x-strong="G35880"
+\zaln-s | x-content="πόδα" x-lemma="πούς" x-morph="Gr,N,,,,,AMS," x-occurrence="1" x-occurrences="1" x-strong="G42280"
+\w foot|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-e\*
+\zaln-s | x-content="πρὸς" x-lemma="πρός" x-morph="Gr,P,,,,,A,,," x-occurrence="1" x-occurrences="1" x-strong="G43140"
+\w against|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-content="λίθον" x-lemma="λίθος" x-morph="Gr,N,,,,,AMS," x-occurrence="1" x-occurrences="1" x-strong="G30370"
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w stone|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*.'"
+\m
+
+\s5

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.whitespace.usfm
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/mat-4-6.whitespace.usfm
@@ -68,7 +68,7 @@
 \zaln-s | x-content="σοῦ" x-lemma="σύ" x-morph="Gr,RP,,,2G,S," x-occurrence="1" x-occurrences="1" x-strong="G47710"
 \w you|x-occurrence="2" x-occurrences="4"\w*
 \zaln-e\*,'
-\m
+\m 
 \zaln-s | x-content="καὶ" x-lemma="καί" x-morph="Gr,CC,,,,,,,," x-occurrence="2" x-occurrences="2" x-strong="G25320"
 \w and|x-occurrence="2" x-occurrences="2"\w*
 \zaln-e\*,
@@ -91,7 +91,7 @@
 \w their|x-occurrence="1" x-occurrences="1"\w*
 \w hands|x-occurrence="1" x-occurrences="1"\w*
 \zaln-e\*,
-\q
+\q 
 \zaln-s | x-content="μήποτε" x-lemma="μήποτε" x-morph="Gr,CS,,,,,,,," x-occurrence="1" x-occurrences="1" x-strong="G33790"
 \w so|x-occurrence="1" x-occurrences="1"\w*
 \w that|x-occurrence="1" x-occurrences="1"\w*

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/v_1ti3-16.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/v_1ti3-16.json
@@ -169,7 +169,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "type": "text",
@@ -264,7 +265,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "strong": "G13440",
@@ -343,7 +345,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "strong": "G37080",
@@ -403,7 +406,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "strong": "G27840",
@@ -475,7 +479,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "strong": "G41000",
@@ -561,7 +566,8 @@
     },
     {
       "tag": "q",
-      "type": "quote"
+      "type": "quote",
+      "nextChar": " "
     },
     {
       "strong": "G25320",

--- a/__tests__/fixtures/verseObjects/heb-12-27.grc.json
+++ b/__tests__/fixtures/verseObjects/heb-12-27.grc.json
@@ -1,0 +1,288 @@
+{
+  "verseObjects": [
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,RD,,,,NNS,",
+          "strong": "G35880",
+          "tag": "w",
+          "text": "τὸ",
+          "type": "word"
+        },
+        {
+          "lemma": "δέ",
+          "morph": "Gr,CC,,,,,,,,",
+          "strong": "G11610",
+          "tag": "w",
+          "text": "δὲ",
+          "type": "word"
+        },
+        {
+          "text": ",\n“",
+          "type": "text"
+        },
+        {
+          "lemma": "ἔτι",
+          "morph": "Gr,D,,,,,,,,,",
+          "strong": "G20890",
+          "tag": "w",
+          "text": "ἔτι",
+          "type": "word"
+        },
+        {
+          "lemma": "ἅπαξ",
+          "morph": "Gr,D,,,,,,,,,",
+          "strong": "G05300",
+          "tag": "w",
+          "text": "ἅπαξ",
+          "type": "word"
+        },
+        {
+          "text": "”,",
+          "type": "text"
+        },
+        {
+          "lemma": "δηλόω",
+          "morph": "Gr,V,IPA3,,S,",
+          "strong": "G12130",
+          "tag": "w",
+          "text": "δηλοῖ",
+          "type": "word"
+        },
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,RD,,,,GNP,",
+          "strong": "G35880",
+          "tag": "w",
+          "text": "τῶν",
+          "type": "word"
+        },
+        {
+          "lemma": "σαλεύω",
+          "morph": "Gr,V,PPP,GNP,",
+          "strong": "G45310",
+          "tag": "w",
+          "text": "σαλευομένων",
+          "type": "word"
+        },
+        {
+          "lemma": "μετάθεσις",
+          "morph": "Gr,N,,,,,AFS,",
+          "strong": "G33310",
+          "tag": "w",
+          "text": "μετάθεσιν",
+          "type": "word"
+        },
+        {
+          "text": ",",
+          "type": "text"
+        },
+        {
+          "lemma": "ὡς",
+          "morph": "Gr,CS,,,,,,,,",
+          "strong": "G56130",
+          "tag": "w",
+          "text": "ὡς",
+          "tw": "rc://*/tw/dict/bible/other/like",
+          "type": "word"
+        },
+        {
+          "lemma": "ποιέω",
+          "morph": "Gr,V,PEP,GNP,",
+          "strong": "G41600",
+          "tag": "w",
+          "text": "πεποιημένων",
+          "type": "word"
+        },
+        {
+          "text": ",",
+          "type": "text"
+        },
+        {
+          "lemma": "ἵνα",
+          "morph": "Gr,CS,,,,,,,,",
+          "strong": "G24430",
+          "tag": "w",
+          "text": "ἵνα",
+          "type": "word"
+        },
+        {
+          "lemma": "μένω",
+          "morph": "Gr,V,SAA3,,S,",
+          "strong": "G33060",
+          "tag": "w",
+          "text": "μείνῃ",
+          "type": "word"
+        },
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,RD,,,,NNP,",
+          "strong": "G35880",
+          "tag": "w",
+          "text": "τὰ",
+          "type": "word"
+        },
+        {
+          "lemma": "μή",
+          "morph": "Gr,D,,,,,,,,,",
+          "strong": "G33610",
+          "tag": "w",
+          "text": "μὴ",
+          "type": "word"
+        },
+        {
+          "lemma": "σαλεύω",
+          "morph": "Gr,V,PPP,NNP,",
+          "strong": "G45310",
+          "tag": "w",
+          "text": "σαλευόμενα",
+          "type": "word"
+        },
+        {
+          "text": ".\n",
+          "type": "text"
+        }
+    ],
+  "wordList": [
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,NNS,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τὸ",
+      "type": "word"
+    },
+    {
+      "lemma": "δέ",
+      "morph": "Gr,CC,,,,,,,,",
+      "strong": "G11610",
+      "tag": "w",
+      "text": "δὲ",
+      "type": "word"
+    },
+    {
+      "text": ",\n“",
+      "type": "text"
+    },
+    {
+      "lemma": "ἔτι",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G20890",
+      "tag": "w",
+      "text": "ἔτι",
+      "type": "word"
+    },
+    {
+      "lemma": "ἅπαξ",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G05300",
+      "tag": "w",
+      "text": "ἅπαξ",
+      "type": "word"
+    },
+    {
+      "text": "”,",
+      "type": "text"
+    },
+    {
+      "lemma": "δηλόω",
+      "morph": "Gr,V,IPA3,,S,",
+      "strong": "G12130",
+      "tag": "w",
+      "text": "δηλοῖ",
+      "type": "word"
+    },
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,GNP,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τῶν",
+      "type": "word"
+    },
+    {
+      "lemma": "σαλεύω",
+      "morph": "Gr,V,PPP,GNP,",
+      "strong": "G45310",
+      "tag": "w",
+      "text": "σαλευομένων",
+      "type": "word"
+    },
+    {
+      "lemma": "μετάθεσις",
+      "morph": "Gr,N,,,,,AFS,",
+      "strong": "G33310",
+      "tag": "w",
+      "text": "μετάθεσιν",
+      "type": "word"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "lemma": "ὡς",
+      "morph": "Gr,CS,,,,,,,,",
+      "strong": "G56130",
+      "tag": "w",
+      "text": "ὡς",
+      "tw": "rc://*/tw/dict/bible/other/like",
+      "type": "word"
+    },
+    {
+      "lemma": "ποιέω",
+      "morph": "Gr,V,PEP,GNP,",
+      "strong": "G41600",
+      "tag": "w",
+      "text": "πεποιημένων",
+      "type": "word"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "lemma": "ἵνα",
+      "morph": "Gr,CS,,,,,,,,",
+      "strong": "G24430",
+      "tag": "w",
+      "text": "ἵνα",
+      "type": "word"
+    },
+    {
+      "lemma": "μένω",
+      "morph": "Gr,V,SAA3,,S,",
+      "strong": "G33060",
+      "tag": "w",
+      "text": "μείνῃ",
+      "type": "word"
+    },
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,NNP,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τὰ",
+      "type": "word"
+    },
+    {
+      "lemma": "μή",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G33610",
+      "tag": "w",
+      "text": "μὴ",
+      "type": "word"
+    },
+    {
+      "lemma": "σαλεύω",
+      "morph": "Gr,V,PPP,NNP,",
+      "strong": "G45310",
+      "tag": "w",
+      "text": "σαλευόμενα",
+      "type": "word"
+    },
+    {
+      "text": ".\n",
+      "type": "text"
+    }
+  ]
+}

--- a/__tests__/fixtures/verseObjects/mat-4-6.grk.json
+++ b/__tests__/fixtures/verseObjects/mat-4-6.grk.json
@@ -1,0 +1,288 @@
+{
+  "verseObjects": [
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,RD,,,,NNS,",
+          "strong": "G35880",
+          "tag": "w",
+          "text": "τὸ",
+          "type": "word"
+        },
+        {
+          "lemma": "δέ",
+          "morph": "Gr,CC,,,,,,,,",
+          "strong": "G11610",
+          "tag": "w",
+          "text": "δὲ",
+          "type": "word"
+        },
+        {
+          "text": ",\n“",
+          "type": "text"
+        },
+        {
+          "lemma": "ἔτι",
+          "morph": "Gr,D,,,,,,,,,",
+          "strong": "G20890",
+          "tag": "w",
+          "text": "ἔτι",
+          "type": "word"
+        },
+        {
+          "lemma": "ἅπαξ",
+          "morph": "Gr,D,,,,,,,,,",
+          "strong": "G05300",
+          "tag": "w",
+          "text": "ἅπαξ",
+          "type": "word"
+        },
+        {
+          "text": "”,",
+          "type": "text"
+        },
+        {
+          "lemma": "δηλόω",
+          "morph": "Gr,V,IPA3,,S,",
+          "strong": "G12130",
+          "tag": "w",
+          "text": "δηλοῖ",
+          "type": "word"
+        },
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,RD,,,,GNP,",
+          "strong": "G35880",
+          "tag": "w",
+          "text": "τῶν",
+          "type": "word"
+        },
+        {
+          "lemma": "σαλεύω",
+          "morph": "Gr,V,PPP,GNP,",
+          "strong": "G45310",
+          "tag": "w",
+          "text": "σαλευομένων",
+          "type": "word"
+        },
+        {
+          "lemma": "μετάθεσις",
+          "morph": "Gr,N,,,,,AFS,",
+          "strong": "G33310",
+          "tag": "w",
+          "text": "μετάθεσιν",
+          "type": "word"
+        },
+        {
+          "text": ",",
+          "type": "text"
+        },
+        {
+          "lemma": "ὡς",
+          "morph": "Gr,CS,,,,,,,,",
+          "strong": "G56130",
+          "tag": "w",
+          "text": "ὡς",
+          "tw": "rc://*/tw/dict/bible/other/like",
+          "type": "word"
+        },
+        {
+          "lemma": "ποιέω",
+          "morph": "Gr,V,PEP,GNP,",
+          "strong": "G41600",
+          "tag": "w",
+          "text": "πεποιημένων",
+          "type": "word"
+        },
+        {
+          "text": ",",
+          "type": "text"
+        },
+        {
+          "lemma": "ἵνα",
+          "morph": "Gr,CS,,,,,,,,",
+          "strong": "G24430",
+          "tag": "w",
+          "text": "ἵνα",
+          "type": "word"
+        },
+        {
+          "lemma": "μένω",
+          "morph": "Gr,V,SAA3,,S,",
+          "strong": "G33060",
+          "tag": "w",
+          "text": "μείνῃ",
+          "type": "word"
+        },
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,RD,,,,NNP,",
+          "strong": "G35880",
+          "tag": "w",
+          "text": "τὰ",
+          "type": "word"
+        },
+        {
+          "lemma": "μή",
+          "morph": "Gr,D,,,,,,,,,",
+          "strong": "G33610",
+          "tag": "w",
+          "text": "μὴ",
+          "type": "word"
+        },
+        {
+          "lemma": "σαλεύω",
+          "morph": "Gr,V,PPP,NNP,",
+          "strong": "G45310",
+          "tag": "w",
+          "text": "σαλευόμενα",
+          "type": "word"
+        },
+        {
+          "text": ".\n",
+          "type": "text"
+        }
+    ],
+  "wordList": [
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,NNS,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τὸ",
+      "type": "word"
+    },
+    {
+      "lemma": "δέ",
+      "morph": "Gr,CC,,,,,,,,",
+      "strong": "G11610",
+      "tag": "w",
+      "text": "δὲ",
+      "type": "word"
+    },
+    {
+      "text": ",\n“",
+      "type": "text"
+    },
+    {
+      "lemma": "ἔτι",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G20890",
+      "tag": "w",
+      "text": "ἔτι",
+      "type": "word"
+    },
+    {
+      "lemma": "ἅπαξ",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G05300",
+      "tag": "w",
+      "text": "ἅπαξ",
+      "type": "word"
+    },
+    {
+      "text": "”,",
+      "type": "text"
+    },
+    {
+      "lemma": "δηλόω",
+      "morph": "Gr,V,IPA3,,S,",
+      "strong": "G12130",
+      "tag": "w",
+      "text": "δηλοῖ",
+      "type": "word"
+    },
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,GNP,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τῶν",
+      "type": "word"
+    },
+    {
+      "lemma": "σαλεύω",
+      "morph": "Gr,V,PPP,GNP,",
+      "strong": "G45310",
+      "tag": "w",
+      "text": "σαλευομένων",
+      "type": "word"
+    },
+    {
+      "lemma": "μετάθεσις",
+      "morph": "Gr,N,,,,,AFS,",
+      "strong": "G33310",
+      "tag": "w",
+      "text": "μετάθεσιν",
+      "type": "word"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "lemma": "ὡς",
+      "morph": "Gr,CS,,,,,,,,",
+      "strong": "G56130",
+      "tag": "w",
+      "text": "ὡς",
+      "tw": "rc://*/tw/dict/bible/other/like",
+      "type": "word"
+    },
+    {
+      "lemma": "ποιέω",
+      "morph": "Gr,V,PEP,GNP,",
+      "strong": "G41600",
+      "tag": "w",
+      "text": "πεποιημένων",
+      "type": "word"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "lemma": "ἵνα",
+      "morph": "Gr,CS,,,,,,,,",
+      "strong": "G24430",
+      "tag": "w",
+      "text": "ἵνα",
+      "type": "word"
+    },
+    {
+      "lemma": "μένω",
+      "morph": "Gr,V,SAA3,,S,",
+      "strong": "G33060",
+      "tag": "w",
+      "text": "μείνῃ",
+      "type": "word"
+    },
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,NNP,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τὰ",
+      "type": "word"
+    },
+    {
+      "lemma": "μή",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G33610",
+      "tag": "w",
+      "text": "μὴ",
+      "type": "word"
+    },
+    {
+      "lemma": "σαλεύω",
+      "morph": "Gr,V,PPP,NNP,",
+      "strong": "G45310",
+      "tag": "w",
+      "text": "σαλευόμενα",
+      "type": "word"
+    },
+    {
+      "text": ".\n",
+      "type": "text"
+    }
+  ]
+}

--- a/__tests__/fixtures/verseObjects/mat-4-6.json
+++ b/__tests__/fixtures/verseObjects/mat-4-6.json
@@ -1,288 +1,784 @@
-{
-  "verseObjects": [
-        {
-          "lemma": "ὁ",
-          "morph": "Gr,RD,,,,NNS,",
-          "strong": "G35880",
-          "tag": "w",
-          "text": "τὸ",
-          "type": "word"
-        },
-        {
-          "lemma": "δέ",
-          "morph": "Gr,CC,,,,,,,,",
-          "strong": "G11610",
-          "tag": "w",
-          "text": "δὲ",
-          "type": "word"
-        },
-        {
-          "text": ",\n“",
-          "type": "text"
-        },
-        {
-          "lemma": "ἔτι",
-          "morph": "Gr,D,,,,,,,,,",
-          "strong": "G20890",
-          "tag": "w",
-          "text": "ἔτι",
-          "type": "word"
-        },
-        {
-          "lemma": "ἅπαξ",
-          "morph": "Gr,D,,,,,,,,,",
-          "strong": "G05300",
-          "tag": "w",
-          "text": "ἅπαξ",
-          "type": "word"
-        },
-        {
-          "text": "”,",
-          "type": "text"
-        },
-        {
-          "lemma": "δηλόω",
-          "morph": "Gr,V,IPA3,,S,",
-          "strong": "G12130",
-          "tag": "w",
-          "text": "δηλοῖ",
-          "type": "word"
-        },
-        {
-          "lemma": "ὁ",
-          "morph": "Gr,RD,,,,GNP,",
-          "strong": "G35880",
-          "tag": "w",
-          "text": "τῶν",
-          "type": "word"
-        },
-        {
-          "lemma": "σαλεύω",
-          "morph": "Gr,V,PPP,GNP,",
-          "strong": "G45310",
-          "tag": "w",
-          "text": "σαλευομένων",
-          "type": "word"
-        },
-        {
-          "lemma": "μετάθεσις",
-          "morph": "Gr,N,,,,,AFS,",
-          "strong": "G33310",
-          "tag": "w",
-          "text": "μετάθεσιν",
-          "type": "word"
-        },
-        {
-          "text": ",",
-          "type": "text"
-        },
-        {
-          "lemma": "ὡς",
-          "morph": "Gr,CS,,,,,,,,",
-          "strong": "G56130",
-          "tag": "w",
-          "text": "ὡς",
-          "tw": "rc://*/tw/dict/bible/other/like",
-          "type": "word"
-        },
-        {
-          "lemma": "ποιέω",
-          "morph": "Gr,V,PEP,GNP,",
-          "strong": "G41600",
-          "tag": "w",
-          "text": "πεποιημένων",
-          "type": "word"
-        },
-        {
-          "text": ",",
-          "type": "text"
-        },
-        {
-          "lemma": "ἵνα",
-          "morph": "Gr,CS,,,,,,,,",
-          "strong": "G24430",
-          "tag": "w",
-          "text": "ἵνα",
-          "type": "word"
-        },
-        {
-          "lemma": "μένω",
-          "morph": "Gr,V,SAA3,,S,",
-          "strong": "G33060",
-          "tag": "w",
-          "text": "μείνῃ",
-          "type": "word"
-        },
-        {
-          "lemma": "ὁ",
-          "morph": "Gr,RD,,,,NNP,",
-          "strong": "G35880",
-          "tag": "w",
-          "text": "τὰ",
-          "type": "word"
-        },
-        {
-          "lemma": "μή",
-          "morph": "Gr,D,,,,,,,,,",
-          "strong": "G33610",
-          "tag": "w",
-          "text": "μὴ",
-          "type": "word"
-        },
-        {
-          "lemma": "σαλεύω",
-          "morph": "Gr,V,PPP,NNP,",
-          "strong": "G45310",
-          "tag": "w",
-          "text": "σαλευόμενα",
-          "type": "word"
-        },
-        {
-          "text": ".\n",
-          "type": "text"
-        }
+[
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G25320",
+    "lemma": "καί",
+    "morph": "Gr,CC,,,,,,,,",
+    "occurrence": 1,
+    "occurrences": 2,
+    "content": "καὶ",
+    "children": [
+      {
+        "text": "and",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
     ],
-  "wordList": [
-    {
-      "lemma": "ὁ",
-      "morph": "Gr,RD,,,,NNS,",
-      "strong": "G35880",
-      "tag": "w",
-      "text": "τὸ",
-      "type": "word"
-    },
-    {
-      "lemma": "δέ",
-      "morph": "Gr,CC,,,,,,,,",
-      "strong": "G11610",
-      "tag": "w",
-      "text": "δὲ",
-      "type": "word"
-    },
-    {
-      "text": ",\n“",
-      "type": "text"
-    },
-    {
-      "lemma": "ἔτι",
-      "morph": "Gr,D,,,,,,,,,",
-      "strong": "G20890",
-      "tag": "w",
-      "text": "ἔτι",
-      "type": "word"
-    },
-    {
-      "lemma": "ἅπαξ",
-      "morph": "Gr,D,,,,,,,,,",
-      "strong": "G05300",
-      "tag": "w",
-      "text": "ἅπαξ",
-      "type": "word"
-    },
-    {
-      "text": "”,",
-      "type": "text"
-    },
-    {
-      "lemma": "δηλόω",
-      "morph": "Gr,V,IPA3,,S,",
-      "strong": "G12130",
-      "tag": "w",
-      "text": "δηλοῖ",
-      "type": "word"
-    },
-    {
-      "lemma": "ὁ",
-      "morph": "Gr,RD,,,,GNP,",
-      "strong": "G35880",
-      "tag": "w",
-      "text": "τῶν",
-      "type": "word"
-    },
-    {
-      "lemma": "σαλεύω",
-      "morph": "Gr,V,PPP,GNP,",
-      "strong": "G45310",
-      "tag": "w",
-      "text": "σαλευομένων",
-      "type": "word"
-    },
-    {
-      "lemma": "μετάθεσις",
-      "morph": "Gr,N,,,,,AFS,",
-      "strong": "G33310",
-      "tag": "w",
-      "text": "μετάθεσιν",
-      "type": "word"
-    },
-    {
-      "text": ",",
-      "type": "text"
-    },
-    {
-      "lemma": "ὡς",
-      "morph": "Gr,CS,,,,,,,,",
-      "strong": "G56130",
-      "tag": "w",
-      "text": "ὡς",
-      "tw": "rc://*/tw/dict/bible/other/like",
-      "type": "word"
-    },
-    {
-      "lemma": "ποιέω",
-      "morph": "Gr,V,PEP,GNP,",
-      "strong": "G41600",
-      "tag": "w",
-      "text": "πεποιημένων",
-      "type": "word"
-    },
-    {
-      "text": ",",
-      "type": "text"
-    },
-    {
-      "lemma": "ἵνα",
-      "morph": "Gr,CS,,,,,,,,",
-      "strong": "G24430",
-      "tag": "w",
-      "text": "ἵνα",
-      "type": "word"
-    },
-    {
-      "lemma": "μένω",
-      "morph": "Gr,V,SAA3,,S,",
-      "strong": "G33060",
-      "tag": "w",
-      "text": "μείνῃ",
-      "type": "word"
-    },
-    {
-      "lemma": "ὁ",
-      "morph": "Gr,RD,,,,NNP,",
-      "strong": "G35880",
-      "tag": "w",
-      "text": "τὰ",
-      "type": "word"
-    },
-    {
-      "lemma": "μή",
-      "morph": "Gr,D,,,,,,,,,",
-      "strong": "G33610",
-      "tag": "w",
-      "text": "μὴ",
-      "type": "word"
-    },
-    {
-      "lemma": "σαλεύω",
-      "morph": "Gr,V,PPP,NNP,",
-      "strong": "G45310",
-      "tag": "w",
-      "text": "σαλευόμενα",
-      "type": "word"
-    },
-    {
-      "text": ".\n",
-      "type": "text"
-    }
-  ]
-}
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G30040",
+    "lemma": "λέγω",
+    "morph": "Gr,V,IPA3,,S,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "λέγει",
+    "children": [
+      {
+        "text": "said",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G08460",
+    "lemma": "αὐτός",
+    "morph": "Gr,RP,,,3DMS,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "αὐτῷ",
+    "children": [
+      {
+        "text": "to",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 2
+      },
+      {
+        "text": "him",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "type": "text",
+    "text": ",\""
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G14870",
+    "lemma": "εἰ",
+    "morph": "Gr,CS,,,,,,,,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "εἰ",
+    "children": [
+      {
+        "text": "If",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G52070",
+    "lemma": "υἱός",
+    "morph": "Gr,N,,,,,NMS,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "Υἱὸς",
+    "children": [
+      {
+        "tag": "zaln",
+        "type": "milestone",
+        "strong": "G15100",
+        "lemma": "εἰμί",
+        "morph": "Gr,V,IPA2,,S,",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": "εἶ",
+        "children": [
+          {
+            "text": "you",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 4
+          },
+          {
+            "text": "are",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          },
+          {
+            "text": "the",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          },
+          {
+            "text": "Son",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "endTag": "zaln-e\\*"
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G35880",
+    "lemma": "ὁ",
+    "morph": "Gr,EA,,,,GMS,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "τοῦ",
+    "children": [
+      {
+        "tag": "zaln",
+        "type": "milestone",
+        "strong": "G23160",
+        "lemma": "θεός",
+        "morph": "Gr,N,,,,,GMS,",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": "Θεοῦ",
+        "children": [
+          {
+            "text": "of",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 2
+          },
+          {
+            "text": "God",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "endTag": "zaln-e\\*"
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "type": "text",
+    "text": ","
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G09060",
+    "lemma": "βάλλω",
+    "morph": "Gr,V,MAA2,,S,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "βάλε",
+    "children": [
+      {
+        "text": "throw",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G45720",
+    "lemma": "σεαυτοῦ",
+    "morph": "Gr,RE,,,2AMS,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "σεαυτὸν",
+    "children": [
+      {
+        "text": "yourself",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G27360",
+    "lemma": "κάτω",
+    "morph": "Gr,D,,,,,,,,,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "κάτω",
+    "children": [
+      {
+        "text": "down",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "type": "text",
+    "text": ","
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G10630",
+    "lemma": "γάρ",
+    "morph": "Gr,CC,,,,,,,,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "γὰρ",
+    "children": [
+      {
+        "text": "for",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G11250",
+    "lemma": "γράφω",
+    "morph": "Gr,V,IEP3,,S,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "γέγραπται",
+    "children": [
+      {
+        "text": "it",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "text": "is",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "text": "written",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "type": "text",
+    "text": ","
+  },
+  {
+    "tag": "q",
+    "type": "quote",
+    "text": "'"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G17810",
+    "lemma": "ἐντέλλω",
+    "morph": "Gr,V,IFM3,,S,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "ἐντελεῖται",
+    "children": [
+      {
+        "text": "He",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "text": "will",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 3
+      },
+      {
+        "text": "command",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G35880",
+    "lemma": "ὁ",
+    "morph": "Gr,EA,,,,DMP,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "τοῖς",
+    "children": [
+      {
+        "tag": "zaln",
+        "type": "milestone",
+        "strong": "G00320",
+        "lemma": "ἄγγελος",
+        "morph": "Gr,N,,,,,DMP,",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": "ἀγγέλοις",
+        "children": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "G08460",
+            "lemma": "αὐτός",
+            "morph": "Gr,RP,,,3GMS,",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "αὐτοῦ",
+            "children": [
+              {
+                "text": "his",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1
+              },
+              {
+                "text": "angels",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1
+              },
+              {
+                "text": "to",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ],
+        "endTag": "zaln-e\\*"
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "text": "take",
+    "tag": "w",
+    "type": "word",
+    "occurrence": 1,
+    "occurrences": 1
+  },
+  {
+    "text": "care",
+    "tag": "w",
+    "type": "word",
+    "occurrence": 1,
+    "occurrences": 1
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G40120",
+    "lemma": "περί",
+    "morph": "Gr,P,,,,,G,,,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "περὶ",
+    "children": [
+      {
+        "text": "of",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 2,
+        "occurrences": 2
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G47710",
+    "lemma": "σύ",
+    "morph": "Gr,RP,,,2G,S,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "σοῦ",
+    "children": [
+      {
+        "text": "you",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 2,
+        "occurrences": 4
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "type": "text",
+    "text": ",'"
+  },
+  {
+    "tag": "m",
+    "type": "paragraph",
+    "text": "and,\n"
+  },
+  {
+    "tag": "q",
+    "type": "quote",
+    "text": "'"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "lemma": "αἴρω",
+    "morph": "Gr,V,IFA3,,P,",
+    "strong": "G01420",
+    "occurrence": 1,
+    "occurrences": 1,
+    "alignmentIndex": "18",
+    "wordIndex": "1",
+    "alignmentLength": "2",
+    "content": "ἀροῦσίν",
+    "children": [
+      {
+        "tag": "zaln",
+        "type": "milestone",
+        "strong": "G47710",
+        "lemma": "σύ",
+        "morph": "Gr,RP,,,2A,S,",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": "σε",
+        "children": [
+          {
+            "text": "They",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          },
+          {
+            "text": "will",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 2,
+            "occurrences": 3
+          },
+          {
+            "text": "lift",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          },
+          {
+            "text": "you",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 3,
+            "occurrences": 4
+          },
+          {
+            "text": "up",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "endTag": "zaln-e\\*"
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G19090",
+    "lemma": "ἐπί",
+    "morph": "Gr,P,,,,,G,,,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "ἐπὶ",
+    "children": [
+      {
+        "text": "in",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "text": "their",
+    "tag": "w",
+    "type": "word",
+    "occurrence": 1,
+    "occurrences": 1
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G54950",
+    "lemma": "χείρ",
+    "morph": "Gr,N,,,,,GFP,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "χειρῶν",
+    "children": [
+      {
+        "text": "hands",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "type": "text",
+    "text": ","
+  },
+  {
+    "tag": "q",
+    "type": "quote"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G33790",
+    "lemma": "μήποτε",
+    "morph": "Gr,CS,,,,,,,,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "μήποτε",
+    "children": [
+      {
+        "text": "so",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "text": "that",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "text": "you",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 4,
+        "occurrences": 4
+      },
+      {
+        "text": "will",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 3,
+        "occurrences": 3
+      },
+      {
+        "text": "not",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G43500",
+    "lemma": "προσκόπτω",
+    "morph": "Gr,V,SAA2,,S,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "προσκόψῃς",
+    "children": [
+      {
+        "text": "hit",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G35880",
+    "lemma": "ὁ",
+    "morph": "Gr,EA,,,,AMS,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "τὸν",
+    "children": [
+      {
+        "tag": "zaln",
+        "type": "milestone",
+        "strong": "G42280",
+        "lemma": "πούς",
+        "morph": "Gr,N,,,,,AMS,",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": "πόδα",
+        "children": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "G47710",
+            "lemma": "σύ",
+            "morph": "Gr,RP,,,2G,S,",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "σου",
+            "children": [
+              {
+                "text": "your",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1
+              },
+              {
+                "text": "foot",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ],
+        "endTag": "zaln-e\\*"
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G43140",
+    "lemma": "πρός",
+    "morph": "Gr,P,,,,,A,,,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "πρὸς",
+    "children": [
+      {
+        "text": "against",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "tag": "zaln",
+    "type": "milestone",
+    "strong": "G30370",
+    "lemma": "λίθος",
+    "morph": "Gr,N,,,,,AMS,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "content": "λίθον",
+    "children": [
+      {
+        "text": "a",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      },
+      {
+        "text": "stone",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1
+      }
+    ],
+    "endTag": "zaln-e\\*"
+  },
+  {
+    "type": "text",
+    "text": ".'\""
+  },
+  {
+    "tag": "m",
+    "nextChar": "\n",
+    "type": "paragraph"
+  },
+  {
+    "type": "text",
+    "text": "\n"
+  },
+  {
+    "tag": "s5",
+    "type": "section"
+  }
+]

--- a/__tests__/fixtures/verseObjects/mat-4-6.json
+++ b/__tests__/fixtures/verseObjects/mat-4-6.json
@@ -1,0 +1,288 @@
+{
+  "verseObjects": [
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,RD,,,,NNS,",
+          "strong": "G35880",
+          "tag": "w",
+          "text": "τὸ",
+          "type": "word"
+        },
+        {
+          "lemma": "δέ",
+          "morph": "Gr,CC,,,,,,,,",
+          "strong": "G11610",
+          "tag": "w",
+          "text": "δὲ",
+          "type": "word"
+        },
+        {
+          "text": ",\n“",
+          "type": "text"
+        },
+        {
+          "lemma": "ἔτι",
+          "morph": "Gr,D,,,,,,,,,",
+          "strong": "G20890",
+          "tag": "w",
+          "text": "ἔτι",
+          "type": "word"
+        },
+        {
+          "lemma": "ἅπαξ",
+          "morph": "Gr,D,,,,,,,,,",
+          "strong": "G05300",
+          "tag": "w",
+          "text": "ἅπαξ",
+          "type": "word"
+        },
+        {
+          "text": "”,",
+          "type": "text"
+        },
+        {
+          "lemma": "δηλόω",
+          "morph": "Gr,V,IPA3,,S,",
+          "strong": "G12130",
+          "tag": "w",
+          "text": "δηλοῖ",
+          "type": "word"
+        },
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,RD,,,,GNP,",
+          "strong": "G35880",
+          "tag": "w",
+          "text": "τῶν",
+          "type": "word"
+        },
+        {
+          "lemma": "σαλεύω",
+          "morph": "Gr,V,PPP,GNP,",
+          "strong": "G45310",
+          "tag": "w",
+          "text": "σαλευομένων",
+          "type": "word"
+        },
+        {
+          "lemma": "μετάθεσις",
+          "morph": "Gr,N,,,,,AFS,",
+          "strong": "G33310",
+          "tag": "w",
+          "text": "μετάθεσιν",
+          "type": "word"
+        },
+        {
+          "text": ",",
+          "type": "text"
+        },
+        {
+          "lemma": "ὡς",
+          "morph": "Gr,CS,,,,,,,,",
+          "strong": "G56130",
+          "tag": "w",
+          "text": "ὡς",
+          "tw": "rc://*/tw/dict/bible/other/like",
+          "type": "word"
+        },
+        {
+          "lemma": "ποιέω",
+          "morph": "Gr,V,PEP,GNP,",
+          "strong": "G41600",
+          "tag": "w",
+          "text": "πεποιημένων",
+          "type": "word"
+        },
+        {
+          "text": ",",
+          "type": "text"
+        },
+        {
+          "lemma": "ἵνα",
+          "morph": "Gr,CS,,,,,,,,",
+          "strong": "G24430",
+          "tag": "w",
+          "text": "ἵνα",
+          "type": "word"
+        },
+        {
+          "lemma": "μένω",
+          "morph": "Gr,V,SAA3,,S,",
+          "strong": "G33060",
+          "tag": "w",
+          "text": "μείνῃ",
+          "type": "word"
+        },
+        {
+          "lemma": "ὁ",
+          "morph": "Gr,RD,,,,NNP,",
+          "strong": "G35880",
+          "tag": "w",
+          "text": "τὰ",
+          "type": "word"
+        },
+        {
+          "lemma": "μή",
+          "morph": "Gr,D,,,,,,,,,",
+          "strong": "G33610",
+          "tag": "w",
+          "text": "μὴ",
+          "type": "word"
+        },
+        {
+          "lemma": "σαλεύω",
+          "morph": "Gr,V,PPP,NNP,",
+          "strong": "G45310",
+          "tag": "w",
+          "text": "σαλευόμενα",
+          "type": "word"
+        },
+        {
+          "text": ".\n",
+          "type": "text"
+        }
+    ],
+  "wordList": [
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,NNS,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τὸ",
+      "type": "word"
+    },
+    {
+      "lemma": "δέ",
+      "morph": "Gr,CC,,,,,,,,",
+      "strong": "G11610",
+      "tag": "w",
+      "text": "δὲ",
+      "type": "word"
+    },
+    {
+      "text": ",\n“",
+      "type": "text"
+    },
+    {
+      "lemma": "ἔτι",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G20890",
+      "tag": "w",
+      "text": "ἔτι",
+      "type": "word"
+    },
+    {
+      "lemma": "ἅπαξ",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G05300",
+      "tag": "w",
+      "text": "ἅπαξ",
+      "type": "word"
+    },
+    {
+      "text": "”,",
+      "type": "text"
+    },
+    {
+      "lemma": "δηλόω",
+      "morph": "Gr,V,IPA3,,S,",
+      "strong": "G12130",
+      "tag": "w",
+      "text": "δηλοῖ",
+      "type": "word"
+    },
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,GNP,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τῶν",
+      "type": "word"
+    },
+    {
+      "lemma": "σαλεύω",
+      "morph": "Gr,V,PPP,GNP,",
+      "strong": "G45310",
+      "tag": "w",
+      "text": "σαλευομένων",
+      "type": "word"
+    },
+    {
+      "lemma": "μετάθεσις",
+      "morph": "Gr,N,,,,,AFS,",
+      "strong": "G33310",
+      "tag": "w",
+      "text": "μετάθεσιν",
+      "type": "word"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "lemma": "ὡς",
+      "morph": "Gr,CS,,,,,,,,",
+      "strong": "G56130",
+      "tag": "w",
+      "text": "ὡς",
+      "tw": "rc://*/tw/dict/bible/other/like",
+      "type": "word"
+    },
+    {
+      "lemma": "ποιέω",
+      "morph": "Gr,V,PEP,GNP,",
+      "strong": "G41600",
+      "tag": "w",
+      "text": "πεποιημένων",
+      "type": "word"
+    },
+    {
+      "text": ",",
+      "type": "text"
+    },
+    {
+      "lemma": "ἵνα",
+      "morph": "Gr,CS,,,,,,,,",
+      "strong": "G24430",
+      "tag": "w",
+      "text": "ἵνα",
+      "type": "word"
+    },
+    {
+      "lemma": "μένω",
+      "morph": "Gr,V,SAA3,,S,",
+      "strong": "G33060",
+      "tag": "w",
+      "text": "μείνῃ",
+      "type": "word"
+    },
+    {
+      "lemma": "ὁ",
+      "morph": "Gr,RD,,,,NNP,",
+      "strong": "G35880",
+      "tag": "w",
+      "text": "τὰ",
+      "type": "word"
+    },
+    {
+      "lemma": "μή",
+      "morph": "Gr,D,,,,,,,,,",
+      "strong": "G33610",
+      "tag": "w",
+      "text": "μὴ",
+      "type": "word"
+    },
+    {
+      "lemma": "σαλεύω",
+      "morph": "Gr,V,PPP,NNP,",
+      "strong": "G45310",
+      "tag": "w",
+      "text": "σαλευόμενα",
+      "type": "word"
+    },
+    {
+      "text": ".\n",
+      "type": "text"
+    }
+  ]
+}

--- a/__tests__/fixtures/verseObjects/mat-4-6.json
+++ b/__tests__/fixtures/verseObjects/mat-4-6.json
@@ -1,781 +1,844 @@
 [
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G25320",
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 2,
+        "tag": "w",
+        "text": "and",
+        "type": "word"
+      }
+    ],
+    "content": "καὶ",
     "lemma": "καί",
     "morph": "Gr,CC,,,,,,,,",
     "occurrence": 1,
     "occurrences": 2,
-    "content": "καὶ",
-    "children": [
-      {
-        "text": "and",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G25320",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G30040",
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "said",
+        "type": "word"
+      }
+    ],
+    "content": "λέγει",
     "lemma": "λέγω",
     "morph": "Gr,V,IPA3,,S,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "λέγει",
-    "children": [
-      {
-        "text": "said",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G30040",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G08460",
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 2,
+        "tag": "w",
+        "text": "to",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "him",
+        "type": "word"
+      }
+    ],
+    "content": "αὐτῷ",
     "lemma": "αὐτός",
     "morph": "Gr,RP,,,3DMS,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "αὐτῷ",
+    "strong": "G08460",
+    "tag": "zaln",
+    "type": "milestone"
+  },
+  {
+    "text": ", ",
+    "type": "text"
+  },
+  {
+    "text": "\"",
+    "type": "text"
+  },
+  {
     "children": [
       {
-        "text": "to",
-        "tag": "w",
-        "type": "word",
         "occurrence": 1,
-        "occurrences": 2
-      },
-      {
-        "text": "him",
+        "occurrences": 1,
         "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
+        "text": "If",
+        "type": "word"
       }
     ],
-    "endTag": "zaln-e\\*"
-  },
-  {
-    "type": "text",
-    "text": ",\""
-  },
-  {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G14870",
+    "content": "εἰ",
     "lemma": "εἰ",
     "morph": "Gr,CS,,,,,,,,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "εἰ",
-    "children": [
-      {
-        "text": "If",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G14870",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 4,
+        "tag": "w",
+        "text": "you",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "are",
+        "type": "word"
+      }
+    ],
+    "content": "εἶ",
+    "lemma": "εἰμί",
+    "morph": "Gr,V,IPA2,,S,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "strong": "G15100",
     "tag": "zaln",
-    "type": "milestone",
-    "strong": "G52070",
+    "type": "milestone"
+  },
+  {
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "the",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "Son",
+        "type": "word"
+      }
+    ],
+    "content": "Υἱὸς",
     "lemma": "υἱός",
     "morph": "Gr,N,,,,,NMS,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "Υἱὸς",
-    "children": [
-      {
-        "tag": "zaln",
-        "type": "milestone",
-        "strong": "G15100",
-        "lemma": "εἰμί",
-        "morph": "Gr,V,IPA2,,S,",
-        "occurrence": 1,
-        "occurrences": 1,
-        "content": "εἶ",
-        "children": [
-          {
-            "text": "you",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 1,
-            "occurrences": 4
-          },
-          {
-            "text": "are",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 1,
-            "occurrences": 1
-          },
-          {
-            "text": "the",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 1,
-            "occurrences": 1
-          },
-          {
-            "text": "Son",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 1,
-            "occurrences": 1
-          }
-        ],
-        "endTag": "zaln-e\\*"
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G52070",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G35880",
-    "lemma": "ὁ",
-    "morph": "Gr,EA,,,,GMS,",
-    "occurrence": 1,
-    "occurrences": 1,
-    "content": "τοῦ",
     "children": [
       {
-        "tag": "zaln",
-        "type": "milestone",
-        "strong": "G23160",
+        "children": [
+          {
+            "occurrence": 1,
+            "occurrences": 2,
+            "tag": "w",
+            "text": "of",
+            "type": "word"
+          },
+          {
+            "occurrence": 1,
+            "occurrences": 1,
+            "tag": "w",
+            "text": "God",
+            "type": "word"
+          }
+        ],
+        "content": "Θεοῦ",
         "lemma": "θεός",
         "morph": "Gr,N,,,,,GMS,",
         "occurrence": 1,
         "occurrences": 1,
-        "content": "Θεοῦ",
-        "children": [
-          {
-            "text": "of",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 1,
-            "occurrences": 2
-          },
-          {
-            "text": "God",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 1,
-            "occurrences": 1
-          }
-        ],
-        "endTag": "zaln-e\\*"
+        "strong": "G23160",
+        "tag": "zaln",
+        "type": "milestone"
       }
     ],
-    "endTag": "zaln-e\\*"
-  },
-  {
-    "type": "text",
-    "text": ","
-  },
-  {
+    "content": "τοῦ",
+    "lemma": "ὁ",
+    "morph": "Gr,EA,,,,GMS,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "strong": "G35880",
     "tag": "zaln",
-    "type": "milestone",
-    "strong": "G09060",
+    "type": "milestone"
+  },
+  {
+    "text": ", ",
+    "type": "text"
+  },
+  {
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "throw",
+        "type": "word"
+      }
+    ],
+    "content": "βάλε",
     "lemma": "βάλλω",
     "morph": "Gr,V,MAA2,,S,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "βάλε",
-    "children": [
-      {
-        "text": "throw",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G09060",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G45720",
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "yourself",
+        "type": "word"
+      }
+    ],
+    "content": "σεαυτὸν",
     "lemma": "σεαυτοῦ",
     "morph": "Gr,RE,,,2AMS,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "σεαυτὸν",
-    "children": [
-      {
-        "text": "yourself",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G45720",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G27360",
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "down",
+        "type": "word"
+      }
+    ],
+    "content": "κάτω",
     "lemma": "κάτω",
     "morph": "Gr,D,,,,,,,,,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "κάτω",
+    "strong": "G27360",
+    "tag": "zaln",
+    "type": "milestone"
+  },
+  {
+    "text": ", ",
+    "type": "text"
+  },
+  {
     "children": [
       {
-        "text": "down",
-        "tag": "w",
-        "type": "word",
         "occurrence": 1,
-        "occurrences": 1
+        "occurrences": 1,
+        "tag": "w",
+        "text": "for",
+        "type": "word"
       }
     ],
-    "endTag": "zaln-e\\*"
-  },
-  {
-    "type": "text",
-    "text": ","
-  },
-  {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G10630",
+    "content": "γὰρ",
     "lemma": "γάρ",
     "morph": "Gr,CC,,,,,,,,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "γὰρ",
-    "children": [
-      {
-        "text": "for",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G10630",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G11250",
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "it",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "is",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "written",
+        "type": "word"
+      }
+    ],
+    "content": "γέγραπται",
     "lemma": "γράφω",
     "morph": "Gr,V,IEP3,,S,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "γέγραπται",
-    "children": [
-      {
-        "text": "it",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      },
-      {
-        "text": "is",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      },
-      {
-        "text": "written",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G11250",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "type": "text",
-    "text": ","
+    "text": ",\n",
+    "type": "text"
   },
   {
     "tag": "q",
     "type": "quote",
-    "text": "'"
+    "nextChar": " "
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G17810",
+    "text": "'",
+    "type": "text"
+  },
+  {
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "He",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 3,
+        "tag": "w",
+        "text": "will",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "command",
+        "type": "word"
+      }
+    ],
+    "content": "ἐντελεῖται",
     "lemma": "ἐντέλλω",
     "morph": "Gr,V,IFM3,,S,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "ἐντελεῖται",
-    "children": [
-      {
-        "text": "He",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      },
-      {
-        "text": "will",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 3
-      },
-      {
-        "text": "command",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G17810",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G35880",
-    "lemma": "ὁ",
-    "morph": "Gr,EA,,,,DMP,",
-    "occurrence": 1,
-    "occurrences": 1,
-    "content": "τοῖς",
     "children": [
       {
-        "tag": "zaln",
-        "type": "milestone",
-        "strong": "G00320",
-        "lemma": "ἄγγελος",
-        "morph": "Gr,N,,,,,DMP,",
         "occurrence": 1,
         "occurrences": 1,
-        "content": "ἀγγέλοις",
-        "children": [
-          {
-            "tag": "zaln",
-            "type": "milestone",
-            "strong": "G08460",
-            "lemma": "αὐτός",
-            "morph": "Gr,RP,,,3GMS,",
-            "occurrence": 1,
-            "occurrences": 1,
-            "content": "αὐτοῦ",
-            "children": [
-              {
-                "text": "his",
-                "tag": "w",
-                "type": "word",
-                "occurrence": 1,
-                "occurrences": 1
-              },
-              {
-                "text": "angels",
-                "tag": "w",
-                "type": "word",
-                "occurrence": 1,
-                "occurrences": 1
-              },
-              {
-                "text": "to",
-                "tag": "w",
-                "type": "word",
-                "occurrence": 2,
-                "occurrences": 2
-              }
-            ],
-            "endTag": "zaln-e\\*"
-          }
-        ],
-        "endTag": "zaln-e\\*"
+        "tag": "w",
+        "text": "his",
+        "type": "word"
       }
     ],
-    "endTag": "zaln-e\\*"
-  },
-  {
-    "text": "take",
-    "tag": "w",
-    "type": "word",
+    "content": "αὐτοῦ",
+    "lemma": "αὐτός",
+    "morph": "Gr,RP,,,3GMS,",
     "occurrence": 1,
-    "occurrences": 1
-  },
-  {
-    "text": "care",
-    "tag": "w",
-    "type": "word",
-    "occurrence": 1,
-    "occurrences": 1
-  },
-  {
+    "occurrences": 1,
+    "strong": "G08460",
     "tag": "zaln",
-    "type": "milestone",
-    "strong": "G40120",
+    "type": "milestone"
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "occurrence": 1,
+                "occurrences": 1,
+                "tag": "w",
+                "text": "angels",
+                "type": "word"
+              }
+            ],
+            "content": "ἀγγέλοις",
+            "lemma": "ἄγγελος",
+            "morph": "Gr,N,,,,,DMP,",
+            "occurrence": 1,
+            "occurrences": 1,
+            "strong": "G00320",
+            "tag": "zaln",
+            "type": "milestone"
+          }
+        ],
+        "content": "τοῖς",
+        "lemma": "ὁ",
+        "morph": "Gr,EA,,,,DMP,",
+        "occurrence": 1,
+        "occurrences": 1,
+        "strong": "G35880",
+        "tag": "zaln",
+        "type": "milestone"
+      }
+    ],
+    "content": "ὅτι",
+    "lemma": "ὅτι",
+    "morph": "Gr,CS,,,,,,,,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "strong": "G37540",
+    "tag": "zaln",
+    "type": "milestone"
+  },
+  {
+    "children": [
+      {
+        "occurrence": 2,
+        "occurrences": 2,
+        "tag": "w",
+        "text": "to",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "take",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "care",
+        "type": "word"
+      },
+      {
+        "occurrence": 2,
+        "occurrences": 2,
+        "tag": "w",
+        "text": "of",
+        "type": "word"
+      }
+    ],
+    "content": "περὶ",
     "lemma": "περί",
     "morph": "Gr,P,,,,,G,,,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "περὶ",
-    "children": [
-      {
-        "text": "of",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 2,
-        "occurrences": 2
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G40120",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G47710",
+    "children": [
+      {
+        "occurrence": 2,
+        "occurrences": 4,
+        "tag": "w",
+        "text": "you",
+        "type": "word"
+      }
+    ],
+    "content": "σοῦ",
     "lemma": "σύ",
     "morph": "Gr,RP,,,2G,S,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "σοῦ",
-    "children": [
-      {
-        "text": "you",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 2,
-        "occurrences": 4
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G47710",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "type": "text",
-    "text": ",'"
+    "text": ",",
+    "type": "text"
+  },
+  {
+    "text": "'\n",
+    "type": "text"
   },
   {
     "tag": "m",
     "type": "paragraph",
-    "text": "and,\n"
+    "nextChar": " "
+  },
+  {
+    "children": [
+      {
+        "occurrence": 2,
+        "occurrences": 2,
+        "tag": "w",
+        "text": "and",
+        "type": "word"
+      }
+    ],
+    "content": "καὶ",
+    "lemma": "καί",
+    "morph": "Gr,CC,,,,,,,,",
+    "occurrence": 2,
+    "occurrences": 2,
+    "strong": "G25320",
+    "tag": "zaln",
+    "type": "milestone"
+  },
+  {
+    "text": ",\n",
+    "type": "text"
   },
   {
     "tag": "q",
     "type": "quote",
-    "text": "'"
+    "nextChar": " "
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "lemma": "αἴρω",
-    "morph": "Gr,V,IFA3,,P,",
-    "strong": "G01420",
-    "occurrence": 1,
-    "occurrences": 1,
-    "alignmentIndex": "18",
-    "wordIndex": "1",
-    "alignmentLength": "2",
-    "content": "ἀροῦσίν",
+    "text": "'",
+    "type": "text"
+  },
+  {
     "children": [
       {
-        "tag": "zaln",
-        "type": "milestone",
-        "strong": "G47710",
-        "lemma": "σύ",
-        "morph": "Gr,RP,,,2A,S,",
         "occurrence": 1,
         "occurrences": 1,
-        "content": "σε",
-        "children": [
-          {
-            "text": "They",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 1,
-            "occurrences": 1
-          },
-          {
-            "text": "will",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 2,
-            "occurrences": 3
-          },
-          {
-            "text": "lift",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 1,
-            "occurrences": 1
-          },
-          {
-            "text": "you",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 3,
-            "occurrences": 4
-          },
-          {
-            "text": "up",
-            "tag": "w",
-            "type": "word",
-            "occurrence": 1,
-            "occurrences": 1
-          }
-        ],
-        "endTag": "zaln-e\\*"
+        "tag": "w",
+        "text": "They",
+        "type": "word"
+      },
+      {
+        "occurrence": 2,
+        "occurrences": 3,
+        "tag": "w",
+        "text": "will",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "lift",
+        "type": "word"
       }
     ],
-    "endTag": "zaln-e\\*"
+    "content": "ἀροῦσίν",
+    "lemma": "αἴρω",
+    "morph": "Gr,V,IFA3,,P,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "strong": "G01420",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
+    "children": [
+      {
+        "occurrence": 3,
+        "occurrences": 4,
+        "tag": "w",
+        "text": "you",
+        "type": "word"
+      }
+    ],
+    "content": "σε",
+    "lemma": "σύ",
+    "morph": "Gr,RP,,,2A,S,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "strong": "G47710",
     "tag": "zaln",
-    "type": "milestone",
-    "strong": "G19090",
+    "type": "milestone"
+  },
+  {
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "up",
+        "type": "word"
+      }
+    ],
+    "content": "ἀροῦσίν",
+    "lemma": "αἴρω",
+    "morph": "Gr,V,IFA3,,P,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "strong": "G01420",
+    "tag": "zaln",
+    "type": "milestone"
+  },
+  {
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "in",
+        "type": "word"
+      }
+    ],
+    "content": "ἐπὶ",
     "lemma": "ἐπί",
     "morph": "Gr,P,,,,,G,,,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "ἐπὶ",
+    "strong": "G19090",
+    "tag": "zaln",
+    "type": "milestone"
+  },
+  {
     "children": [
       {
-        "text": "in",
-        "tag": "w",
-        "type": "word",
         "occurrence": 1,
-        "occurrences": 1
+        "occurrences": 1,
+        "tag": "w",
+        "text": "their",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "hands",
+        "type": "word"
       }
     ],
-    "endTag": "zaln-e\\*"
-  },
-  {
-    "text": "their",
-    "tag": "w",
-    "type": "word",
-    "occurrence": 1,
-    "occurrences": 1
-  },
-  {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G54950",
+    "content": "χειρῶν",
     "lemma": "χείρ",
     "morph": "Gr,N,,,,,GFP,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "χειρῶν",
-    "children": [
-      {
-        "text": "hands",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G54950",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "type": "text",
-    "text": ","
+    "text": ",\n",
+    "type": "text"
   },
   {
     "tag": "q",
-    "type": "quote"
+    "type": "quote",
+    "nextChar": " "
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G33790",
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "so",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "that",
+        "type": "word"
+      }
+    ],
+    "content": "μήποτε",
     "lemma": "μήποτε",
     "morph": "Gr,CS,,,,,,,,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "μήποτε",
-    "children": [
-      {
-        "text": "so",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      },
-      {
-        "text": "that",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      },
-      {
-        "text": "you",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 4,
-        "occurrences": 4
-      },
-      {
-        "text": "will",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 3,
-        "occurrences": 3
-      },
-      {
-        "text": "not",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G33790",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G43500",
+    "children": [
+      {
+        "occurrence": 4,
+        "occurrences": 4,
+        "tag": "w",
+        "text": "you",
+        "type": "word"
+      },
+      {
+        "occurrence": 3,
+        "occurrences": 3,
+        "tag": "w",
+        "text": "will",
+        "type": "word"
+      }
+    ],
+    "content": "προσκόψῃς",
     "lemma": "προσκόπτω",
     "morph": "Gr,V,SAA2,,S,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "προσκόψῃς",
-    "children": [
-      {
-        "text": "hit",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G43500",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G35880",
-    "lemma": "ὁ",
-    "morph": "Gr,EA,,,,AMS,",
-    "occurrence": 1,
-    "occurrences": 1,
-    "content": "τὸν",
     "children": [
       {
-        "tag": "zaln",
-        "type": "milestone",
-        "strong": "G42280",
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "not",
+        "type": "word"
+      }
+    ],
+    "content": "μήποτε",
+    "lemma": "μήποτε",
+    "morph": "Gr,CS,,,,,,,,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "strong": "G33790",
+    "tag": "zaln",
+    "type": "milestone"
+  },
+  {
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "hit",
+        "type": "word"
+      }
+    ],
+    "content": "προσκόψῃς",
+    "lemma": "προσκόπτω",
+    "morph": "Gr,V,SAA2,,S,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "strong": "G43500",
+    "tag": "zaln",
+    "type": "milestone"
+  },
+  {
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "your",
+        "type": "word"
+      }
+    ],
+    "content": "σου",
+    "lemma": "σύ",
+    "morph": "Gr,RP,,,2G,S,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "strong": "G47710",
+    "tag": "zaln",
+    "type": "milestone"
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "occurrence": 1,
+            "occurrences": 1,
+            "tag": "w",
+            "text": "foot",
+            "type": "word"
+          }
+        ],
+        "content": "πόδα",
         "lemma": "πούς",
         "morph": "Gr,N,,,,,AMS,",
         "occurrence": 1,
         "occurrences": 1,
-        "content": "πόδα",
-        "children": [
-          {
-            "tag": "zaln",
-            "type": "milestone",
-            "strong": "G47710",
-            "lemma": "σύ",
-            "morph": "Gr,RP,,,2G,S,",
-            "occurrence": 1,
-            "occurrences": 1,
-            "content": "σου",
-            "children": [
-              {
-                "text": "your",
-                "tag": "w",
-                "type": "word",
-                "occurrence": 1,
-                "occurrences": 1
-              },
-              {
-                "text": "foot",
-                "tag": "w",
-                "type": "word",
-                "occurrence": 1,
-                "occurrences": 1
-              }
-            ],
-            "endTag": "zaln-e\\*"
-          }
-        ],
-        "endTag": "zaln-e\\*"
+        "strong": "G42280",
+        "tag": "zaln",
+        "type": "milestone"
       }
     ],
-    "endTag": "zaln-e\\*"
+    "content": "τὸν",
+    "lemma": "ὁ",
+    "morph": "Gr,EA,,,,AMS,",
+    "occurrence": 1,
+    "occurrences": 1,
+    "strong": "G35880",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G43140",
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "against",
+        "type": "word"
+      }
+    ],
+    "content": "πρὸς",
     "lemma": "πρός",
     "morph": "Gr,P,,,,,A,,,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "πρὸς",
-    "children": [
-      {
-        "text": "against",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G43140",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "tag": "zaln",
-    "type": "milestone",
-    "strong": "G30370",
+    "children": [
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "a",
+        "type": "word"
+      },
+      {
+        "occurrence": 1,
+        "occurrences": 1,
+        "tag": "w",
+        "text": "stone",
+        "type": "word"
+      }
+    ],
+    "content": "λίθον",
     "lemma": "λίθος",
     "morph": "Gr,N,,,,,AMS,",
     "occurrence": 1,
     "occurrences": 1,
-    "content": "λίθον",
-    "children": [
-      {
-        "text": "a",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      },
-      {
-        "text": "stone",
-        "tag": "w",
-        "type": "word",
-        "occurrence": 1,
-        "occurrences": 1
-      }
-    ],
-    "endTag": "zaln-e\\*"
+    "strong": "G30370",
+    "tag": "zaln",
+    "type": "milestone"
   },
   {
-    "type": "text",
-    "text": ".'\""
+    "text": ".",
+    "type": "text"
   },
   {
-    "tag": "m",
+    "text": "'",
+    "type": "text"
+  },
+  {
+    "text": "\"\n",
+    "type": "text"
+  },
+  {
     "nextChar": "\n",
+    "tag": "m",
     "type": "paragraph"
   },
   {
-    "type": "text",
-    "text": "\n"
+    "text": "\n",
+    "type": "text"
   },
   {
     "tag": "s5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7251,11 +7251,10 @@
       "dev": true
     },
     "usfm-js": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.4.tgz",
-      "integrity": "sha512-OmR47r0hrsTJ3ZrvmBizOX6yfi0NjTx7eMB5hbssKG446t70MADWY66JRWmgBC7LHQvOnQczLrlUKNzKpHDr5g==",
+      "version": "github:translationCoreApps/usfm-js#b00a7432a6fec3a2992fbb2c9d9454ec6a9d6799",
       "requires": {
         "babel-runtime": "6.26.0",
+        "lodash": "4.17.11",
         "rimraf": "2.6.2",
         "transform-runtime": "0.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A library for handling word alignment",
   "main": "lib/index.js",
   "scripts": {
@@ -58,6 +58,6 @@
     "rimraf": "^2.6.2",
     "string-punctuation-tokenizer": "0.9.1",
     "transform-runtime": "0.0.0",
-    "usfm-js": "^1.0.6"
+    "usfm-js": "github:translationCoreApps/usfm-js#bugfix-mcleanb-5063"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "rimraf": "^2.6.2",
     "string-punctuation-tokenizer": "0.9.1",
     "transform-runtime": "0.0.0",
-    "usfm-js": "github:translationCoreApps/usfm-js#bugfix-mcleanb-5063"
+    "usfm-js": "^1.0.7"
   }
 }

--- a/src/js/utils/verseObjects.js
+++ b/src/js/utils/verseObjects.js
@@ -227,6 +227,12 @@ const getWordsFromNestedVerseObjects = (verseObjects, newVerseObjects, wordMap, 
     if ((verseObject.type !== 'text')) {
       // preseserve non-text verseObject except for text part which will be split into words
       delete verseObject.text;
+      if (vsObjText) {
+        if (verseObject.nextChar) {
+          vsObjText += verseObject.nextChar; // preserve next char
+        }
+        verseObject.nextChar = ' '; // preserve space before text
+      }
       newVerseObjects.push(verseObject);
       if (verseObject.children) {
         const newChildVerseObjects = [];

--- a/src/js/utils/verseObjects.js
+++ b/src/js/utils/verseObjects.js
@@ -310,6 +310,7 @@ export const milestoneVerseObjectFromTopWord = topWord => {
   verseObject.type = "milestone";
   verseObject.content = topWord.word;
   delete verseObject.word;
+  delete verseObject.endTag;
   delete verseObject.tw;
   return verseObject;
 };
@@ -327,6 +328,7 @@ export const alignmentObjectFromVerseObject = verseObject => {
   delete wordObject.tag;
   delete wordObject.type;
   delete wordObject.children;
+  delete wordObject.endTag;
   return wordObject;
 };
 
@@ -411,7 +413,9 @@ export const mergeVerseData = (verseData, filter) => {
  */
 export const getWordListFromVerseObjectArray = verseObjects => {
   let wordList = [];
-  for (let verseObject of verseObjects) {
+  const length = verseObjects.length;
+  for (let i = 0; i < length; i++) {
+    const verseObject = verseObjects[i];
     const words = extractWordsFromVerseObject(verseObject);
     wordList.push.apply(wordList, words); // fast concat arrays
   }


### PR DESCRIPTION
### Changes
- fixes for white space retention on alignment merge (on export)
- added a bunch of test cases.

### Testing
- unit tests should pass on Travis

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/word-aligner/9)
<!-- Reviewable:end -->
