### PR TITLE
Bugfix 6847/fix to show all target words in SP and word bank and better invalidation checking in WA

### DIFF
--- a/__tests__/AlignmentHelpers.test.js
+++ b/__tests__/AlignmentHelpers.test.js
@@ -8,6 +8,9 @@ import wordaligner, {VerseObjectUtils} from '../src/';
 const RESOURCES = path.join('__tests__', 'fixtures', 'pivotAlignmentVerseObjects');
 
 describe("Merge Alignment into Verse Objects", () => {
+  it('handles nested spans and broken footnotes in Hindi', () => {
+    mergeTest('hi_irv_luk-4-19');
+  });
   it('handles one to one', () => {
     mergeTest('oneToOne');
   });
@@ -82,6 +85,9 @@ describe("Merge Alignment into Verse Objects", () => {
 });
 
 describe("UnMerge Alignment from Verse Objects", () => {
+  it('handles nested spans and broken footnotes in Hindi', () => {
+    mergeTest('hi_irv_luk-4-19');
+  });
   it('handles one to one', () => {
     unmergeTest('oneToOne');
   });

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/hi_irv_luk-4-19.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/hi_irv_luk-4-19.json
@@ -1,0 +1,421 @@
+{
+  "alignedVerseString": "Παῦλος δοῦλος Θεοῦ ἀπόστολος δὲ Ἰησοῦ Χριστοῦ κατὰ πίστιν ἐκλεκτῶν Θεοῦ καὶ ἐπίγνωσιν ἀληθείας τῆς κατ’ εὐσέβειαν",
+  "verseString": "\\wj \\wj*  \\w और|x-occurrence=\"1\" x-occurrences=\"1\"\\w* \\it\\+wj\\w प्रभु|x-occurrence=\"1\" x-occurrences=\"1\"\\w* \\w के|x-occurrence=\"1\" x-occurrences=\"2\"\\w* \\w प्रसन्न|x-occurrence=\"1\" x-occurrences=\"1\"\\w* \\w रहने|x-occurrence=\"1\" x-occurrences=\"1\"\\w* \\w के|x-occurrence=\"2\" x-occurrences=\"2\"\\w* \\w वर्ष|x-occurrence=\"1\" x-occurrences=\"1\"\\w*\\f + \\f*\\f* \\f* \\f*  \\fr 4.19 \\fq प्रभु के प्रसन्न रहने के वर्ष: \\ft बन्दी दास और दासी की; भूमि और सम्पत्ति की; ऋण और दायित्वों से सामान्य छुटकारे का वर्ष; (लैव्य 25: 8)।\\f*    \\+wj* \\it* \\wj \\wj*  \\w का|x-occurrence=\"1\" x-occurrences=\"1\"\\w* \\w प्रचार|x-occurrence=\"1\" x-occurrences=\"1\"\\w* \\w करूँ|x-occurrence=\"1\" x-occurrences=\"1\"\\w*।”\n\\p ",
+  "verseObjects": [
+    {
+      "endTag": "wj*",
+      "nextChar": " ",
+      "tag": "wj"
+    },
+    {
+      "text": "  ",
+      "type": "text"
+    },
+    {
+      "nextChar": " ",
+      "occurrence": "1",
+      "occurrences": "1",
+      "tag": "w",
+      "type": "word"
+    },
+    {
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "w",
+      "text": "और",
+      "type": "word"
+    },
+    {
+      "text": " ",
+      "type": "text"
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "nextChar": " ",
+              "occurrence": "1",
+              "occurrences": "1",
+              "tag": "w",
+              "type": "word"
+            },
+            {
+              "occurrence": 1,
+              "occurrences": 1,
+              "tag": "w",
+              "text": "प्रभु",
+              "type": "word"
+            },
+            {
+              "text": " ",
+              "type": "text"
+            },
+            {
+              "nextChar": " ",
+              "occurrence": "1",
+              "occurrences": "2",
+              "tag": "w",
+              "type": "word"
+            },
+            {
+              "occurrence": 1,
+              "occurrences": 2,
+              "tag": "w",
+              "text": "के",
+              "type": "word"
+            },
+            {
+              "text": " ",
+              "type": "text"
+            },
+            {
+              "nextChar": " ",
+              "occurrence": "1",
+              "occurrences": "1",
+              "tag": "w",
+              "type": "word"
+            },
+            {
+              "occurrence": 1,
+              "occurrences": 1,
+              "tag": "w",
+              "text": "प्रसन्न",
+              "type": "word"
+            },
+            {
+              "text": " ",
+              "type": "text"
+            },
+            {
+              "nextChar": " ",
+              "occurrence": "1",
+              "occurrences": "1",
+              "tag": "w",
+              "type": "word"
+            },
+            {
+              "occurrence": 1,
+              "occurrences": 1,
+              "tag": "w",
+              "text": "रहने",
+              "type": "word"
+            },
+            {
+              "text": " ",
+              "type": "text"
+            },
+            {
+              "nextChar": " ",
+              "occurrence": "2",
+              "occurrences": "2",
+              "tag": "w",
+              "type": "word"
+            },
+            {
+              "occurrence": 2,
+              "occurrences": 2,
+              "tag": "w",
+              "text": "के",
+              "type": "word"
+            },
+            {
+              "text": " ",
+              "type": "text"
+            },
+            {
+              "nextChar": " ",
+              "occurrence": "1",
+              "occurrences": "1",
+              "tag": "w",
+              "type": "word"
+            },
+            {
+              "occurrence": 1,
+              "occurrences": 1,
+              "tag": "w",
+              "text": "वर्ष",
+              "type": "word"
+            },
+            {
+              "content": "+ ",
+              "nesting": 1,
+              "tag": "f",
+              "type": "footnote"
+            }
+          ],
+          "endTag": "",
+          "tag": "+wj"
+        }
+      ],
+      "endTag": "",
+      "tag": "it"
+    },
+    {
+      "tag": "f*"
+    },
+    {
+      "nextChar": " ",
+      "tag": "f*"
+    },
+    {
+      "nextChar": " ",
+      "tag": "f*"
+    },
+    {
+      "text": " ",
+      "type": "text"
+    },
+    {
+      "content": " ",
+      "endMarkerChar": " ",
+      "tag": "f*"
+    },
+    {
+      "content": "4.19 ",
+      "tag": "fr"
+    },
+    {
+      "content": "प्रभु के प्रसन्न रहने के वर्ष: ",
+      "tag": "fq"
+    },
+    {
+      "content": "बन्दी दास और दासी की; भूमि और सम्पत्ति की; ऋण और दायित्वों से सामान्य छुटकारे का वर्ष; (लैव्य 25: 8)।",
+      "tag": "ft"
+    },
+    {
+      "nextChar": " ",
+      "tag": "f*"
+    },
+    {
+      "text": "    ",
+      "type": "text"
+    },
+    {
+      "nextChar": " ",
+      "tag": "+wj*"
+    },
+    {
+      "nextChar": " ",
+      "tag": "it*"
+    },
+    {
+      "endTag": "wj*",
+      "nextChar": " ",
+      "tag": "wj"
+    },
+    {
+      "text": "  ",
+      "type": "text"
+    },
+    {
+      "nextChar": " ",
+      "occurrence": "1",
+      "occurrences": "1",
+      "tag": "w",
+      "type": "word"
+    },
+    {
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "w",
+      "text": "का",
+      "type": "word"
+    },
+    {
+      "text": " ",
+      "type": "text"
+    },
+    {
+      "nextChar": " ",
+      "occurrence": "1",
+      "occurrences": "1",
+      "tag": "w",
+      "type": "word"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "प्रचार",
+          "type": "word"
+        }
+      ],
+      "content": "κηρύξαι",
+      "lemma": "κηρύσσω",
+      "morph": "Gr,V,NAA,,,,,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G27840",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": " ",
+      "type": "text"
+    },
+    {
+      "nextChar": " ",
+      "occurrence": "1",
+      "occurrences": "1",
+      "tag": "w",
+      "type": "word"
+    },
+    {
+      "children": [
+        {
+          "occurrence": 1,
+          "occurrences": 1,
+          "tag": "w",
+          "text": "करूँ",
+          "type": "word"
+        }
+      ],
+      "content": "δεκτόν",
+      "lemma": "δεκτός",
+      "morph": "Gr,NS,,,,AMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "strong": "G11840",
+      "tag": "zaln",
+      "type": "milestone"
+    },
+    {
+      "text": "।",
+      "type": "text"
+    },
+    {
+      "text": "”\n",
+      "type": "text"
+    },
+    {
+      "nextChar": " ",
+      "tag": "p",
+      "type": "paragraph"
+    },
+    {
+      "text": " ",
+      "type": "text"
+    }
+  ],
+  "alignment": [
+    {
+      "topWords": [
+        {
+          "word": "κηρύξαι",
+          "strong": "G27840",
+          "lemma": "κηρύσσω",
+          "morph": "Gr,V,NAA,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "प्रचार",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐνιαυτὸν",
+          "strong": "G17630",
+          "lemma": "ἐνιαυτός",
+          "morph": "Gr,N,,,,,AMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "Κυρίου",
+          "strong": "G29620",
+          "lemma": "κύριος",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "δεκτόν",
+          "strong": "G11840",
+          "lemma": "δεκτός",
+          "morph": "Gr,NS,,,,AMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "करूँ",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
+    }
+  ],
+  "wordBank": [
+    {
+      "word": "और",
+      "occurrence": 1,
+      "occurrences": 1,
+      "type": "bottomWord"
+    },
+    {
+      "word": "के",
+      "occurrence": 1,
+      "occurrences": 2,
+      "type": "bottomWord"
+    },
+    {
+      "word": "प्रसन्न",
+      "occurrence": 1,
+      "occurrences": 1,
+      "type": "bottomWord"
+    },
+    {
+      "word": "के",
+      "occurrence": 2,
+      "occurrences": 2,
+      "type": "bottomWord"
+    },
+    {
+      "word": "प्रभु",
+      "occurrence": 1,
+      "occurrences": 1,
+      "type": "bottomWord"
+    },
+    {
+      "word": "रहने",
+      "occurrence": 1,
+      "occurrences": 1,
+      "type": "bottomWord"
+    },
+    {
+      "word": "वर्ष",
+      "occurrence": 1,
+      "occurrences": 1,
+      "type": "bottomWord"
+    },
+    {
+      "word": "का",
+      "occurrence": 1,
+      "occurrences": 1,
+      "type": "bottomWord"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4730,6 +4730,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -7292,14 +7298,12 @@
       "dev": true
     },
     "usfm-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.0.2.tgz",
-      "integrity": "sha512-9dykXM14qzp8+hp73xr+qz1lljtDPApUukzD/Md/pB0Dp5sAicl7OJLXhBHbQVmOKigpRS+JexIaa9x+yBWWaw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.1.0.tgz",
+      "integrity": "sha512-DemzdzAwrVeuzRwnZYOKvAle/U2ZUUf04NQSVDgqZCSFyH7hVhe2/PWC7jT2DKnPMYoa0IxnG3XGbuOPXgZ/oQ==",
+      "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "lodash": "^4.17.11",
-        "rimraf": "^2.6.3",
-        "transform-runtime": "0.0.0"
+        "lodash.clonedeep": "^4.5.0"
       }
     },
     "util": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A library for handling word alignment",
   "main": "lib/index.js",
   "scripts": {
@@ -37,6 +37,9 @@
     "url": "https://github.com/unfoldingWord/word-aligner/issues"
   },
   "homepage": "https://github.com/unfoldingWord/word-aligner#readme",
+  "peerDependencies": {
+    "usfm-js": "^2.1.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
@@ -49,7 +52,8 @@
     "eslint-config-google": "^0.12.0",
     "eslint-plugin-jest": "^22.1.3",
     "jest": "^23.6.0",
-    "ospath": "1.2.2"
+    "ospath": "1.2.2",
+    "usfm-js": "2.1.0"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -59,7 +63,6 @@
     "path-extra": "^4.2.1",
     "rimraf": "^2.6.2",
     "string-punctuation-tokenizer": "2.0.0",
-    "transform-runtime": "0.0.0",
-    "usfm-js": "2.0.2"
+    "transform-runtime": "0.0.0"
   }
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- make usfm-js a peer dependency

#### Please include detailed Test instructions for your pull request:
- checkout tC branch `bugfix-mcleanb-6847`, run `npm run load-apps && npm ci && npm start`
- use github build attached to https://github.com/unfoldingWord/translationCore/pull/6966
- open project at https://drive.google.com/open?id=1nkSWNnvqHw_QVDaU5dIzNf9GZetrEB4Y
- when you open project, should see 38 new invalidations for WA
- open WA and navigate to luke 4:19
- the old builds would not show invalidations until project was exported, and would only show `4:19 और का प्रचार करूँ।”` in SP and only 4 words in the word bank
- but in this build 4:19 should show invalidated icon.  Also you should see many more words in word bank and SP as:  
![Screen Shot 2020-06-04 at 10 07 47 AM copy](https://user-images.githubusercontent.com/14238574/83773109-20709680-a652-11ea-83d6-12f64bdd2b36.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/word-aligner/59)
<!-- Reviewable:end -->
