### PR TITLE
Bugfix 6990/fix for more than two original language words in alignment

### DIFF
--- a/__tests__/VerseObjectUtils.test.js
+++ b/__tests__/VerseObjectUtils.test.js
@@ -1,6 +1,7 @@
 jest.unmock('fs-extra');
 import fs from 'fs-extra';
 import path from 'path-extra';
+import stringify from 'json-stringify-safe';
 import {VerseObjectUtils} from '../src/';
 
 describe('VerseObjectUtils.sortWordObjectsByString', () => {
@@ -406,5 +407,18 @@ describe("getWordListForVerse", () => {
 
     // then
     expect(results).toEqual(testData.wordList);
+  });
+
+  it('handles multiple original language words in alignment', () => {
+    // given
+    const testFile = path.join('__tests__', 'fixtures', 'verseObjects', 'est-8-6.ust.json');
+    const testData = fs.readJSONSync(testFile);
+
+    // when
+    const results = VerseObjectUtils.getWordListForVerse(testData.verseObjects);
+
+    // then
+    // TRICKY: handle circular references
+    expect(stringify(results, null, 2)).toEqual(stringify(testData.wordList, null, 2));
   });
 });

--- a/__tests__/fixtures/verseObjects/est-8-6.ust.json
+++ b/__tests__/fixtures/verseObjects/est-8-6.ust.json
@@ -1,0 +1,4949 @@
+{
+  "verseObjects": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "“"
+      },
+      {
+        "tag": "zaln",
+        "type": "milestone",
+        "strong": "H3588a",
+        "lemma": "כִּי",
+        "morph": "He,C",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": "כִּ֠י",
+        "children": [
+          {
+            "text": "I",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 2
+          },
+          {
+            "type": "text",
+            "text": " "
+          },
+          {
+            "text": "am",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          },
+          {
+            "type": "text",
+            "text": " "
+          },
+          {
+            "text": "asking",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          },
+          {
+            "type": "text",
+            "text": " "
+          },
+          {
+            "text": "this",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          },
+          {
+            "type": "text",
+            "text": " "
+          },
+          {
+            "text": "because",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "endTag": "zaln-e\\*"
+      },
+      {
+        "type": "text",
+        "text": " "
+      },
+      {
+        "tag": "zaln",
+        "type": "milestone",
+        "strong": "H0349c",
+        "lemma": "אֵיךְ",
+        "morph": "He,Ti",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": "אֵיכָכָ֤ה",
+        "children": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H3201",
+            "lemma": "יָכֹל",
+            "morph": "He,Vqi1cs",
+            "occurrence": 1,
+            "occurrences": 2,
+            "content": "אוּכַל֙",
+            "children": [
+              {
+                "text": "I",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2
+              },
+              {
+                "type": "text",
+                "text": " "
+              },
+              {
+                "text": "could",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1
+              },
+              {
+                "type": "text",
+                "text": " "
+              },
+              {
+                "text": "not",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1
+              },
+              {
+                "type": "text",
+                "text": " "
+              },
+              {
+                "text": "bear",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ],
+        "endTag": "zaln-e\\*"
+      },
+      {
+        "type": "text",
+        "text": " "
+      },
+      {
+        "tag": "zaln",
+        "type": "milestone",
+        "strong": "c:H7200",
+        "lemma": "רָאָה",
+        "morph": "He,C:Vqq1cs",
+        "occurrence": 1,
+        "occurrences": 2,
+        "content": "וְֽ⁠רָאִ֔יתִי",
+        "children": [
+          {
+            "text": "to",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          },
+          {
+            "type": "text",
+            "text": " "
+          },
+          {
+            "text": "see",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "endTag": "zaln-e\\*"
+      },
+      {
+        "type": "text",
+        "text": " "
+      },
+      {
+        "tag": "zaln",
+        "type": "milestone",
+        "strong": "H4138",
+        "lemma": "מוֹלֶדֶת",
+        "morph": "He,Ncfsc:Sp1cs",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": "מוֹלַדְתִּֽ⁠י",
+        "children": [
+          {
+            "text": "my",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 2
+          },
+          {
+            "type": "text",
+            "text": " "
+          },
+          {
+            "text": "relatives",
+            "tag": "w",
+            "type": "word",
+            "occurrence": 1,
+            "occurrences": 1
+          }
+        ],
+        "endTag": "zaln-e\\*"
+      },
+      {
+        "type": "text",
+        "text": " "
+      },
+      {
+        "tag": "zaln",
+        "type": "milestone",
+        "strong": "H0853",
+        "lemma": "אֵת",
+        "morph": "He,To",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": "אֶת",
+        "children": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H5971a",
+            "lemma": "עַם",
+            "morph": "He,Ncmsc:Sp1cs",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "עַמִּ֑⁠י",
+            "children": [
+              {
+                "text": "and",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1
+              },
+              {
+                "type": "text",
+                "text": " "
+              },
+              {
+                "text": "my",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2
+              },
+              {
+                "type": "text",
+                "text": " "
+              },
+              {
+                "text": "whole",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1
+              },
+              {
+                "type": "text",
+                "text": " "
+              },
+              {
+                "text": "people",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ],
+        "endTag": "zaln-e\\*"
+      },
+      {
+        "type": "text",
+        "text": " "
+      },
+      {
+        "tag": "zaln",
+        "type": "milestone",
+        "strong": "b:H7451c",
+        "lemma": "רַע",
+        "morph": "He,Rd:Ncfsa",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": "בָּ⁠רָעָ֖ה",
+        "children": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0834a",
+            "lemma": "אֲשֶׁר",
+            "morph": "He,Tr",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֲשֶׁר",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H4672",
+                "lemma": "מָצָא",
+                "morph": "He,Vqi3ms",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": "יִמְצָ֣א",
+                "children": [
+                  {
+                    "text": "destroyed",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ],
+        "endTag": "zaln-e\\*"
+      },
+      {
+        "type": "text",
+        "text": ".”\n\n"
+      },
+      {
+        "tag": "ts\\*",
+        "nextChar": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": " \n"
+      }
+    ]
+  },
+  "wordList": [
+    {
+      "type": "text",
+      "text": "“"
+    },
+    {
+      "text": "I",
+      "tag": "w",
+      "type": "word",
+      "occurrence": 1,
+      "occurrences": 2,
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H3588a",
+          "lemma": "כִּי",
+          "morph": "He,C",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "כִּ֠י",
+          "children": [
+            "[Circular ~.1]",
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.1.content.0]"
+              ]
+            },
+            {
+              "text": "am",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.1.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.1.content.0]"
+              ]
+            },
+            {
+              "text": "asking",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.1.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.1.content.0]"
+              ]
+            },
+            {
+              "text": "this",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.1.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.1.content.0]"
+              ]
+            },
+            {
+              "text": "because",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.1.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": " ",
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H3588a",
+          "lemma": "כִּי",
+          "morph": "He,C",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "כִּ֠י",
+          "children": [
+            {
+              "text": "I",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 2,
+              "content": [
+                "[Circular ~.2.content.0]"
+              ]
+            },
+            "[Circular ~.2]",
+            {
+              "text": "am",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.2.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.2.content.0]"
+              ]
+            },
+            {
+              "text": "asking",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.2.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.2.content.0]"
+              ]
+            },
+            {
+              "text": "this",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.2.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.2.content.0]"
+              ]
+            },
+            {
+              "text": "because",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.2.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "text": "am",
+      "tag": "w",
+      "type": "word",
+      "occurrence": 1,
+      "occurrences": 1,
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H3588a",
+          "lemma": "כִּי",
+          "morph": "He,C",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "כִּ֠י",
+          "children": [
+            {
+              "text": "I",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 2,
+              "content": [
+                "[Circular ~.3.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.3.content.0]"
+              ]
+            },
+            "[Circular ~.3]",
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.3.content.0]"
+              ]
+            },
+            {
+              "text": "asking",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.3.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.3.content.0]"
+              ]
+            },
+            {
+              "text": "this",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.3.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.3.content.0]"
+              ]
+            },
+            {
+              "text": "because",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.3.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": " ",
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H3588a",
+          "lemma": "כִּי",
+          "morph": "He,C",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "כִּ֠י",
+          "children": [
+            {
+              "text": "I",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 2,
+              "content": [
+                "[Circular ~.4.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.4.content.0]"
+              ]
+            },
+            {
+              "text": "am",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.4.content.0]"
+              ]
+            },
+            "[Circular ~.4]",
+            {
+              "text": "asking",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.4.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.4.content.0]"
+              ]
+            },
+            {
+              "text": "this",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.4.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.4.content.0]"
+              ]
+            },
+            {
+              "text": "because",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.4.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "text": "asking",
+      "tag": "w",
+      "type": "word",
+      "occurrence": 1,
+      "occurrences": 1,
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H3588a",
+          "lemma": "כִּי",
+          "morph": "He,C",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "כִּ֠י",
+          "children": [
+            {
+              "text": "I",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 2,
+              "content": [
+                "[Circular ~.5.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.5.content.0]"
+              ]
+            },
+            {
+              "text": "am",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.5.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.5.content.0]"
+              ]
+            },
+            "[Circular ~.5]",
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.5.content.0]"
+              ]
+            },
+            {
+              "text": "this",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.5.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.5.content.0]"
+              ]
+            },
+            {
+              "text": "because",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.5.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": " ",
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H3588a",
+          "lemma": "כִּי",
+          "morph": "He,C",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "כִּ֠י",
+          "children": [
+            {
+              "text": "I",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 2,
+              "content": [
+                "[Circular ~.6.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.6.content.0]"
+              ]
+            },
+            {
+              "text": "am",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.6.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.6.content.0]"
+              ]
+            },
+            {
+              "text": "asking",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.6.content.0]"
+              ]
+            },
+            "[Circular ~.6]",
+            {
+              "text": "this",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.6.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.6.content.0]"
+              ]
+            },
+            {
+              "text": "because",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.6.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "text": "this",
+      "tag": "w",
+      "type": "word",
+      "occurrence": 1,
+      "occurrences": 1,
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H3588a",
+          "lemma": "כִּי",
+          "morph": "He,C",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "כִּ֠י",
+          "children": [
+            {
+              "text": "I",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 2,
+              "content": [
+                "[Circular ~.7.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.7.content.0]"
+              ]
+            },
+            {
+              "text": "am",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.7.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.7.content.0]"
+              ]
+            },
+            {
+              "text": "asking",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.7.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.7.content.0]"
+              ]
+            },
+            "[Circular ~.7]",
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.7.content.0]"
+              ]
+            },
+            {
+              "text": "because",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.7.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": " ",
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H3588a",
+          "lemma": "כִּי",
+          "morph": "He,C",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "כִּ֠י",
+          "children": [
+            {
+              "text": "I",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 2,
+              "content": [
+                "[Circular ~.8.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.8.content.0]"
+              ]
+            },
+            {
+              "text": "am",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.8.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.8.content.0]"
+              ]
+            },
+            {
+              "text": "asking",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.8.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.8.content.0]"
+              ]
+            },
+            {
+              "text": "this",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.8.content.0]"
+              ]
+            },
+            "[Circular ~.8]",
+            {
+              "text": "because",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.8.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "text": "because",
+      "tag": "w",
+      "type": "word",
+      "occurrence": 1,
+      "occurrences": 1,
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H3588a",
+          "lemma": "כִּי",
+          "morph": "He,C",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "כִּ֠י",
+          "children": [
+            {
+              "text": "I",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 2,
+              "content": [
+                "[Circular ~.9.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.9.content.0]"
+              ]
+            },
+            {
+              "text": "am",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.9.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.9.content.0]"
+              ]
+            },
+            {
+              "text": "asking",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.9.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.9.content.0]"
+              ]
+            },
+            {
+              "text": "this",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.9.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.9.content.0]"
+              ]
+            },
+            "[Circular ~.9]"
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": " "
+    },
+    [
+      {
+        "text": "I",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 2,
+        "occurrences": 2,
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H3201",
+            "lemma": "יָכֹל",
+            "morph": "He,Vqi1cs",
+            "occurrence": 1,
+            "occurrences": 2,
+            "content": "אוּכַל֙",
+            "children": [
+              "[Circular ~.11.0]",
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "could",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "not",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "bear",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0349c",
+            "lemma": "אֵיךְ",
+            "morph": "He,Ti",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֵיכָכָ֤ה",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H3201",
+                "lemma": "יָכֹל",
+                "morph": "He,Vqi1cs",
+                "occurrence": 1,
+                "occurrences": 2,
+                "content": "אוּכַל֙",
+                "children": [
+                  "[Circular ~.11.0]",
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.0.content.1.children.0]",
+                      "[Circular ~.11.0.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "could",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.0.content.1.children.0]",
+                      "[Circular ~.11.0.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.0.content.1.children.0]",
+                      "[Circular ~.11.0.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "not",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.0.content.1.children.0]",
+                      "[Circular ~.11.0.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.0.content.1.children.0]",
+                      "[Circular ~.11.0.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "bear",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.0.content.1.children.0]",
+                      "[Circular ~.11.0.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": " ",
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H3201",
+            "lemma": "יָכֹל",
+            "morph": "He,Vqi1cs",
+            "occurrence": 1,
+            "occurrences": 2,
+            "content": "אוּכַל֙",
+            "children": [
+              {
+                "text": "I",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.11.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.11.1]",
+              {
+                "text": "could",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "not",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "bear",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0349c",
+            "lemma": "אֵיךְ",
+            "morph": "He,Ti",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֵיכָכָ֤ה",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H3201",
+                "lemma": "יָכֹל",
+                "morph": "He,Vqi1cs",
+                "occurrence": 1,
+                "occurrences": 2,
+                "content": "אוּכַל֙",
+                "children": [
+                  {
+                    "text": "I",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.11.1.content.1.children.0]",
+                      "[Circular ~.11.1.content.1]"
+                    ]
+                  },
+                  "[Circular ~.11.1]",
+                  {
+                    "text": "could",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.1.content.1.children.0]",
+                      "[Circular ~.11.1.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.1.content.1.children.0]",
+                      "[Circular ~.11.1.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "not",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.1.content.1.children.0]",
+                      "[Circular ~.11.1.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.1.content.1.children.0]",
+                      "[Circular ~.11.1.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "bear",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.1.content.1.children.0]",
+                      "[Circular ~.11.1.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "text": "could",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H3201",
+            "lemma": "יָכֹל",
+            "morph": "He,Vqi1cs",
+            "occurrence": 1,
+            "occurrences": 2,
+            "content": "אוּכַל֙",
+            "children": [
+              {
+                "text": "I",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.11.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.11.2]",
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "not",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "bear",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0349c",
+            "lemma": "אֵיךְ",
+            "morph": "He,Ti",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֵיכָכָ֤ה",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H3201",
+                "lemma": "יָכֹל",
+                "morph": "He,Vqi1cs",
+                "occurrence": 1,
+                "occurrences": 2,
+                "content": "אוּכַל֙",
+                "children": [
+                  {
+                    "text": "I",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.11.2.content.1.children.0]",
+                      "[Circular ~.11.2.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.2.content.1.children.0]",
+                      "[Circular ~.11.2.content.1]"
+                    ]
+                  },
+                  "[Circular ~.11.2]",
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.2.content.1.children.0]",
+                      "[Circular ~.11.2.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "not",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.2.content.1.children.0]",
+                      "[Circular ~.11.2.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.2.content.1.children.0]",
+                      "[Circular ~.11.2.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "bear",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.2.content.1.children.0]",
+                      "[Circular ~.11.2.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": " ",
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H3201",
+            "lemma": "יָכֹל",
+            "morph": "He,Vqi1cs",
+            "occurrence": 1,
+            "occurrences": 2,
+            "content": "אוּכַל֙",
+            "children": [
+              {
+                "text": "I",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.11.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "could",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.11.3]",
+              {
+                "text": "not",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "bear",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0349c",
+            "lemma": "אֵיךְ",
+            "morph": "He,Ti",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֵיכָכָ֤ה",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H3201",
+                "lemma": "יָכֹל",
+                "morph": "He,Vqi1cs",
+                "occurrence": 1,
+                "occurrences": 2,
+                "content": "אוּכַל֙",
+                "children": [
+                  {
+                    "text": "I",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.11.3.content.1.children.0]",
+                      "[Circular ~.11.3.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.3.content.1.children.0]",
+                      "[Circular ~.11.3.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "could",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.3.content.1.children.0]",
+                      "[Circular ~.11.3.content.1]"
+                    ]
+                  },
+                  "[Circular ~.11.3]",
+                  {
+                    "text": "not",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.3.content.1.children.0]",
+                      "[Circular ~.11.3.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.3.content.1.children.0]",
+                      "[Circular ~.11.3.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "bear",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.3.content.1.children.0]",
+                      "[Circular ~.11.3.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "text": "not",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H3201",
+            "lemma": "יָכֹל",
+            "morph": "He,Vqi1cs",
+            "occurrence": 1,
+            "occurrences": 2,
+            "content": "אוּכַל֙",
+            "children": [
+              {
+                "text": "I",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.11.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "could",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.11.4]",
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "bear",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0349c",
+            "lemma": "אֵיךְ",
+            "morph": "He,Ti",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֵיכָכָ֤ה",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H3201",
+                "lemma": "יָכֹל",
+                "morph": "He,Vqi1cs",
+                "occurrence": 1,
+                "occurrences": 2,
+                "content": "אוּכַל֙",
+                "children": [
+                  {
+                    "text": "I",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.11.4.content.1.children.0]",
+                      "[Circular ~.11.4.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.4.content.1.children.0]",
+                      "[Circular ~.11.4.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "could",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.4.content.1.children.0]",
+                      "[Circular ~.11.4.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.4.content.1.children.0]",
+                      "[Circular ~.11.4.content.1]"
+                    ]
+                  },
+                  "[Circular ~.11.4]",
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.4.content.1.children.0]",
+                      "[Circular ~.11.4.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "bear",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.4.content.1.children.0]",
+                      "[Circular ~.11.4.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": " ",
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H3201",
+            "lemma": "יָכֹל",
+            "morph": "He,Vqi1cs",
+            "occurrence": 1,
+            "occurrences": 2,
+            "content": "אוּכַל֙",
+            "children": [
+              {
+                "text": "I",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.11.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "could",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "not",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.11.5]",
+              {
+                "text": "bear",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0349c",
+            "lemma": "אֵיךְ",
+            "morph": "He,Ti",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֵיכָכָ֤ה",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H3201",
+                "lemma": "יָכֹל",
+                "morph": "He,Vqi1cs",
+                "occurrence": 1,
+                "occurrences": 2,
+                "content": "אוּכַל֙",
+                "children": [
+                  {
+                    "text": "I",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.11.5.content.1.children.0]",
+                      "[Circular ~.11.5.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.5.content.1.children.0]",
+                      "[Circular ~.11.5.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "could",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.5.content.1.children.0]",
+                      "[Circular ~.11.5.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.5.content.1.children.0]",
+                      "[Circular ~.11.5.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "not",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.5.content.1.children.0]",
+                      "[Circular ~.11.5.content.1]"
+                    ]
+                  },
+                  "[Circular ~.11.5]",
+                  {
+                    "text": "bear",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.5.content.1.children.0]",
+                      "[Circular ~.11.5.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "text": "bear",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H3201",
+            "lemma": "יָכֹל",
+            "morph": "He,Vqi1cs",
+            "occurrence": 1,
+            "occurrences": 2,
+            "content": "אוּכַל֙",
+            "children": [
+              {
+                "text": "I",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.11.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "could",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "not",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.11.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.11.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0349c",
+                    "lemma": "אֵיךְ",
+                    "morph": "He,Ti",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֵיכָכָ֤ה",
+                    "children": [
+                      "[Circular ~.11.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.11.6]"
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0349c",
+            "lemma": "אֵיךְ",
+            "morph": "He,Ti",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֵיכָכָ֤ה",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H3201",
+                "lemma": "יָכֹל",
+                "morph": "He,Vqi1cs",
+                "occurrence": 1,
+                "occurrences": 2,
+                "content": "אוּכַל֙",
+                "children": [
+                  {
+                    "text": "I",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.11.6.content.1.children.0]",
+                      "[Circular ~.11.6.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.6.content.1.children.0]",
+                      "[Circular ~.11.6.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "could",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.6.content.1.children.0]",
+                      "[Circular ~.11.6.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.6.content.1.children.0]",
+                      "[Circular ~.11.6.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "not",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.11.6.content.1.children.0]",
+                      "[Circular ~.11.6.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.11.6.content.1.children.0]",
+                      "[Circular ~.11.6.content.1]"
+                    ]
+                  },
+                  "[Circular ~.11.6]"
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      }
+    ],
+    {
+      "type": "text",
+      "text": " "
+    },
+    {
+      "text": "to",
+      "tag": "w",
+      "type": "word",
+      "occurrence": 1,
+      "occurrences": 1,
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "c:H7200",
+          "lemma": "רָאָה",
+          "morph": "He,C:Vqq1cs",
+          "occurrence": 1,
+          "occurrences": 2,
+          "content": "וְֽ⁠רָאִ֔יתִי",
+          "children": [
+            "[Circular ~.13]",
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.13.content.0]"
+              ]
+            },
+            {
+              "text": "see",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.13.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": " ",
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "c:H7200",
+          "lemma": "רָאָה",
+          "morph": "He,C:Vqq1cs",
+          "occurrence": 1,
+          "occurrences": 2,
+          "content": "וְֽ⁠רָאִ֔יתִי",
+          "children": [
+            {
+              "text": "to",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.14.content.0]"
+              ]
+            },
+            "[Circular ~.14]",
+            {
+              "text": "see",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.14.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "text": "see",
+      "tag": "w",
+      "type": "word",
+      "occurrence": 1,
+      "occurrences": 1,
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "c:H7200",
+          "lemma": "רָאָה",
+          "morph": "He,C:Vqq1cs",
+          "occurrence": 1,
+          "occurrences": 2,
+          "content": "וְֽ⁠רָאִ֔יתִי",
+          "children": [
+            {
+              "text": "to",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.15.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.15.content.0]"
+              ]
+            },
+            "[Circular ~.15]"
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": " "
+    },
+    {
+      "text": "my",
+      "tag": "w",
+      "type": "word",
+      "occurrence": 1,
+      "occurrences": 2,
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H4138",
+          "lemma": "מוֹלֶדֶת",
+          "morph": "He,Ncfsc:Sp1cs",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "מוֹלַדְתִּֽ⁠י",
+          "children": [
+            "[Circular ~.17]",
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.17.content.0]"
+              ]
+            },
+            {
+              "text": "relatives",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.17.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": " ",
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H4138",
+          "lemma": "מוֹלֶדֶת",
+          "morph": "He,Ncfsc:Sp1cs",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "מוֹלַדְתִּֽ⁠י",
+          "children": [
+            {
+              "text": "my",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 2,
+              "content": [
+                "[Circular ~.18.content.0]"
+              ]
+            },
+            "[Circular ~.18]",
+            {
+              "text": "relatives",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": [
+                "[Circular ~.18.content.0]"
+              ]
+            }
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "text": "relatives",
+      "tag": "w",
+      "type": "word",
+      "occurrence": 1,
+      "occurrences": 1,
+      "content": [
+        {
+          "tag": "zaln",
+          "type": "milestone",
+          "strong": "H4138",
+          "lemma": "מוֹלֶדֶת",
+          "morph": "He,Ncfsc:Sp1cs",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": "מוֹלַדְתִּֽ⁠י",
+          "children": [
+            {
+              "text": "my",
+              "tag": "w",
+              "type": "word",
+              "occurrence": 1,
+              "occurrences": 2,
+              "content": [
+                "[Circular ~.19.content.0]"
+              ]
+            },
+            {
+              "type": "text",
+              "text": " ",
+              "content": [
+                "[Circular ~.19.content.0]"
+              ]
+            },
+            "[Circular ~.19]"
+          ],
+          "endTag": "zaln-e\\*"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": " "
+    },
+    [
+      {
+        "text": "and",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H5971a",
+            "lemma": "עַם",
+            "morph": "He,Ncmsc:Sp1cs",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "עַמִּ֑⁠י",
+            "children": [
+              "[Circular ~.21.0]",
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "my",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.21.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "whole",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "people",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.0.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.0.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0853",
+            "lemma": "אֵת",
+            "morph": "He,To",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֶת",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H5971a",
+                "lemma": "עַם",
+                "morph": "He,Ncmsc:Sp1cs",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": "עַמִּ֑⁠י",
+                "children": [
+                  "[Circular ~.21.0]",
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.0.content.1.children.0]",
+                      "[Circular ~.21.0.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "my",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.21.0.content.1.children.0]",
+                      "[Circular ~.21.0.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.0.content.1.children.0]",
+                      "[Circular ~.21.0.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "whole",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.0.content.1.children.0]",
+                      "[Circular ~.21.0.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.0.content.1.children.0]",
+                      "[Circular ~.21.0.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "people",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.0.content.1.children.0]",
+                      "[Circular ~.21.0.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": " ",
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H5971a",
+            "lemma": "עַם",
+            "morph": "He,Ncmsc:Sp1cs",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "עַמִּ֑⁠י",
+            "children": [
+              {
+                "text": "and",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.21.1]",
+              {
+                "text": "my",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.21.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "whole",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "people",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.1.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.1.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0853",
+            "lemma": "אֵת",
+            "morph": "He,To",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֶת",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H5971a",
+                "lemma": "עַם",
+                "morph": "He,Ncmsc:Sp1cs",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": "עַמִּ֑⁠י",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.1.content.1.children.0]",
+                      "[Circular ~.21.1.content.1]"
+                    ]
+                  },
+                  "[Circular ~.21.1]",
+                  {
+                    "text": "my",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.21.1.content.1.children.0]",
+                      "[Circular ~.21.1.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.1.content.1.children.0]",
+                      "[Circular ~.21.1.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "whole",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.1.content.1.children.0]",
+                      "[Circular ~.21.1.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.1.content.1.children.0]",
+                      "[Circular ~.21.1.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "people",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.1.content.1.children.0]",
+                      "[Circular ~.21.1.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "text": "my",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 2,
+        "occurrences": 2,
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H5971a",
+            "lemma": "עַם",
+            "morph": "He,Ncmsc:Sp1cs",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "עַמִּ֑⁠י",
+            "children": [
+              {
+                "text": "and",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.21.2]",
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "whole",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "people",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.2.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.2.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0853",
+            "lemma": "אֵת",
+            "morph": "He,To",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֶת",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H5971a",
+                "lemma": "עַם",
+                "morph": "He,Ncmsc:Sp1cs",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": "עַמִּ֑⁠י",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.2.content.1.children.0]",
+                      "[Circular ~.21.2.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.2.content.1.children.0]",
+                      "[Circular ~.21.2.content.1]"
+                    ]
+                  },
+                  "[Circular ~.21.2]",
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.2.content.1.children.0]",
+                      "[Circular ~.21.2.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "whole",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.2.content.1.children.0]",
+                      "[Circular ~.21.2.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.2.content.1.children.0]",
+                      "[Circular ~.21.2.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "people",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.2.content.1.children.0]",
+                      "[Circular ~.21.2.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": " ",
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H5971a",
+            "lemma": "עַם",
+            "morph": "He,Ncmsc:Sp1cs",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "עַמִּ֑⁠י",
+            "children": [
+              {
+                "text": "and",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "my",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.21.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.21.3]",
+              {
+                "text": "whole",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "people",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.3.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.3.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0853",
+            "lemma": "אֵת",
+            "morph": "He,To",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֶת",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H5971a",
+                "lemma": "עַם",
+                "morph": "He,Ncmsc:Sp1cs",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": "עַמִּ֑⁠י",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.3.content.1.children.0]",
+                      "[Circular ~.21.3.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.3.content.1.children.0]",
+                      "[Circular ~.21.3.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "my",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.21.3.content.1.children.0]",
+                      "[Circular ~.21.3.content.1]"
+                    ]
+                  },
+                  "[Circular ~.21.3]",
+                  {
+                    "text": "whole",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.3.content.1.children.0]",
+                      "[Circular ~.21.3.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.3.content.1.children.0]",
+                      "[Circular ~.21.3.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "people",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.3.content.1.children.0]",
+                      "[Circular ~.21.3.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "text": "whole",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H5971a",
+            "lemma": "עַם",
+            "morph": "He,Ncmsc:Sp1cs",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "עַמִּ֑⁠י",
+            "children": [
+              {
+                "text": "and",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "my",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.21.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.21.4]",
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "people",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.4.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.4.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0853",
+            "lemma": "אֵת",
+            "morph": "He,To",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֶת",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H5971a",
+                "lemma": "עַם",
+                "morph": "He,Ncmsc:Sp1cs",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": "עַמִּ֑⁠י",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.4.content.1.children.0]",
+                      "[Circular ~.21.4.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.4.content.1.children.0]",
+                      "[Circular ~.21.4.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "my",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.21.4.content.1.children.0]",
+                      "[Circular ~.21.4.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.4.content.1.children.0]",
+                      "[Circular ~.21.4.content.1]"
+                    ]
+                  },
+                  "[Circular ~.21.4]",
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.4.content.1.children.0]",
+                      "[Circular ~.21.4.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "people",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.4.content.1.children.0]",
+                      "[Circular ~.21.4.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": " ",
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H5971a",
+            "lemma": "עַם",
+            "morph": "He,Ncmsc:Sp1cs",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "עַמִּ֑⁠י",
+            "children": [
+              {
+                "text": "and",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "my",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.21.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "whole",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.21.5]",
+              {
+                "text": "people",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.5.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.5.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0853",
+            "lemma": "אֵת",
+            "morph": "He,To",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֶת",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H5971a",
+                "lemma": "עַם",
+                "morph": "He,Ncmsc:Sp1cs",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": "עַמִּ֑⁠י",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.5.content.1.children.0]",
+                      "[Circular ~.21.5.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.5.content.1.children.0]",
+                      "[Circular ~.21.5.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "my",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.21.5.content.1.children.0]",
+                      "[Circular ~.21.5.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.5.content.1.children.0]",
+                      "[Circular ~.21.5.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "whole",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.5.content.1.children.0]",
+                      "[Circular ~.21.5.content.1]"
+                    ]
+                  },
+                  "[Circular ~.21.5]",
+                  {
+                    "text": "people",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.5.content.1.children.0]",
+                      "[Circular ~.21.5.content.1]"
+                    ]
+                  }
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      },
+      {
+        "text": "people",
+        "tag": "w",
+        "type": "word",
+        "occurrence": 1,
+        "occurrences": 1,
+        "content": [
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H5971a",
+            "lemma": "עַם",
+            "morph": "He,Ncmsc:Sp1cs",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "עַמִּ֑⁠י",
+            "children": [
+              {
+                "text": "and",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "my",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 2,
+                "occurrences": 2,
+                "content": [
+                  "[Circular ~.21.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "text": "whole",
+                "tag": "w",
+                "type": "word",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": [
+                  "[Circular ~.21.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": " ",
+                "content": [
+                  "[Circular ~.21.6.content.0]",
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "strong": "H0853",
+                    "lemma": "אֵת",
+                    "morph": "He,To",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": "אֶת",
+                    "children": [
+                      "[Circular ~.21.6.content.0]"
+                    ],
+                    "endTag": "zaln-e\\*"
+                  }
+                ]
+              },
+              "[Circular ~.21.6]"
+            ],
+            "endTag": "zaln-e\\*"
+          },
+          {
+            "tag": "zaln",
+            "type": "milestone",
+            "strong": "H0853",
+            "lemma": "אֵת",
+            "morph": "He,To",
+            "occurrence": 1,
+            "occurrences": 1,
+            "content": "אֶת",
+            "children": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "strong": "H5971a",
+                "lemma": "עַם",
+                "morph": "He,Ncmsc:Sp1cs",
+                "occurrence": 1,
+                "occurrences": 1,
+                "content": "עַמִּ֑⁠י",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.6.content.1.children.0]",
+                      "[Circular ~.21.6.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.6.content.1.children.0]",
+                      "[Circular ~.21.6.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "my",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2,
+                    "content": [
+                      "[Circular ~.21.6.content.1.children.0]",
+                      "[Circular ~.21.6.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.6.content.1.children.0]",
+                      "[Circular ~.21.6.content.1]"
+                    ]
+                  },
+                  {
+                    "text": "whole",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "content": [
+                      "[Circular ~.21.6.content.1.children.0]",
+                      "[Circular ~.21.6.content.1]"
+                    ]
+                  },
+                  {
+                    "type": "text",
+                    "text": " ",
+                    "content": [
+                      "[Circular ~.21.6.content.1.children.0]",
+                      "[Circular ~.21.6.content.1]"
+                    ]
+                  },
+                  "[Circular ~.21.6]"
+                ],
+                "endTag": "zaln-e\\*"
+              }
+            ],
+            "endTag": "zaln-e\\*"
+          }
+        ]
+      }
+    ],
+    {
+      "type": "text",
+      "text": " "
+    },
+    [
+      [
+        {
+          "text": "destroyed",
+          "tag": "w",
+          "type": "word",
+          "occurrence": 1,
+          "occurrences": 1,
+          "content": [
+            {
+              "tag": "zaln",
+              "type": "milestone",
+              "strong": "H4672",
+              "lemma": "מָצָא",
+              "morph": "He,Vqi3ms",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": "יִמְצָ֣א",
+              "children": [
+                "[Circular ~.23.0.0]"
+              ],
+              "endTag": "zaln-e\\*"
+            },
+            {
+              "tag": "zaln",
+              "type": "milestone",
+              "strong": "H0834a",
+              "lemma": "אֲשֶׁר",
+              "morph": "He,Tr",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": "אֲשֶׁר",
+              "children": [
+                {
+                  "tag": "zaln",
+                  "type": "milestone",
+                  "strong": "H4672",
+                  "lemma": "מָצָא",
+                  "morph": "He,Vqi3ms",
+                  "occurrence": 1,
+                  "occurrences": 1,
+                  "content": "יִמְצָ֣א",
+                  "children": [
+                    "[Circular ~.23.0.0]"
+                  ],
+                  "endTag": "zaln-e\\*"
+                }
+              ],
+              "endTag": "zaln-e\\*"
+            },
+            {
+              "tag": "zaln",
+              "type": "milestone",
+              "strong": "b:H7451c",
+              "lemma": "רַע",
+              "morph": "He,Rd:Ncfsa",
+              "occurrence": 1,
+              "occurrences": 1,
+              "content": "בָּ⁠רָעָ֖ה",
+              "children": [
+                {
+                  "tag": "zaln",
+                  "type": "milestone",
+                  "strong": "H0834a",
+                  "lemma": "אֲשֶׁר",
+                  "morph": "He,Tr",
+                  "occurrence": 1,
+                  "occurrences": 1,
+                  "content": "אֲשֶׁר",
+                  "children": [
+                    {
+                      "tag": "zaln",
+                      "type": "milestone",
+                      "strong": "H4672",
+                      "lemma": "מָצָא",
+                      "morph": "He,Vqi3ms",
+                      "occurrence": 1,
+                      "occurrences": 1,
+                      "content": "יִמְצָ֣א",
+                      "children": [
+                        "[Circular ~.23.0.0]"
+                      ],
+                      "endTag": "zaln-e\\*"
+                    }
+                  ],
+                  "endTag": "zaln-e\\*"
+                }
+              ],
+              "endTag": "zaln-e\\*"
+            }
+          ]
+        }
+      ]
+    ],
+    {
+      "type": "text",
+      "text": ".”\n\n"
+    },
+    {
+      "tag": "ts\\*",
+      "nextChar": "\n"
+    },
+    {
+      "tag": "p",
+      "type": "paragraph",
+      "text": " \n"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.4.1-alpha",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.4.0",
+  "version": "0.4.1-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "A library for handling word alignment",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.4.1-alpha",
+  "version": "0.4.1",
   "description": "A library for handling word alignment",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A library for handling word alignment",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-aligner",
-  "version": "0.4.0",
+  "version": "0.4.1-alpha",
   "description": "A library for handling word alignment",
   "main": "lib/index.js",
   "scripts": {
@@ -51,6 +51,7 @@
     "eslint": "^5.12.1",
     "eslint-config-google": "^0.12.0",
     "eslint-plugin-jest": "^22.1.3",
+    "json-stringify-safe": "5.0.1",
     "jest": "^23.6.0",
     "ospath": "1.2.2",
     "usfm-js": "2.1.0"


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix for more than two original language words in alignment

#### Please include detailed Test instructions for your pull request:
- test with tC branch `bugfix-mcleanb-6990`
- open an Esther project, start tW, add en_ult pane to SP, navigate to Evil and select 8:6.  SHould see "destroyed" highlighted:

![Screen Shot 2020-06-16 at 3 09 33 PM](https://user-images.githubusercontent.com/14238574/84817893-ab06ad80-afe3-11ea-9202-4eca438f3052.png)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/word-aligner/60)
<!-- Reviewable:end -->
